### PR TITLE
Remove proposer bonus

### DIFF
--- a/x/distribution/abci.go
+++ b/x/distribution/abci.go
@@ -29,7 +29,7 @@ func BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock, k keeper.Keeper) 
 	// ref https://github.com/cosmos/cosmos-sdk/issues/3095
 	if ctx.BlockHeight() > 1 {
 		previousProposer := k.GetPreviousProposerConsAddr(ctx)
-		k.AllocateTokens(ctx, sumPreviousPrecommitPower, previousTotalPower, previousProposer, req.LastCommitInfo.GetVotes())
+		k.AllocateTokens(ctx, previousTotalPower, previousProposer, req.LastCommitInfo.GetVotes())
 	}
 
 	// record the proposer for when we payout on the next block

--- a/x/staking/keeper/validator.go
+++ b/x/staking/keeper/validator.go
@@ -150,6 +150,7 @@ func (k Keeper) UpdateValidatorCommission(ctx sdk.Context,
 
 // MustUpdateValidatorCommission updates a validator's commission rate,
 // ignoring the max change rate.
+// This is only intended to get called during the Osmosis v2 upgrade
 func (k Keeper) MustUpdateValidatorCommission(ctx sdk.Context,
 	validator types.Validator, newRate sdk.Dec) (types.Commission, error) {
 	commission := validator.Commission


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

This PR removes the proposer bonus within distribution. This is because Osmosis distributes rewards on an epoch'd basis, and in this setting it doesn't make sense to give this reward to the proposer, since it won't get amortized to all proposers according to stake distribution.

The reason this proposer bonus existed was to incentivize precommit inclusion. However, if you knew ahead of time that a particular block would have a higher reward, this would incentivize not voting on the block until you were the proposer -- clearly harmful. Thus we remove this proposer bonus here.

(This has the additional side affect of removing the slight incentivization of stake centralization that has existed in all SDK chains thus far!)

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
