### PR TITLE
Fix cache_kv_store n^2 problem

### DIFF
--- a/store/cachekv/store.go
+++ b/store/cachekv/store.go
@@ -80,10 +80,6 @@ func (store *Store) Set(key []byte, value []byte) {
 	types.AssertValidValue(value)
 
 	store.setCacheValue(key, value, false, true)
-
-	if len(store.cache) >= 5012 {
-		store.Write()
-	}
 }
 
 // Has implements types.KVStore.

--- a/store/cachekv/store.go
+++ b/store/cachekv/store.go
@@ -80,6 +80,10 @@ func (store *Store) Set(key []byte, value []byte) {
 	types.AssertValidValue(value)
 
 	store.setCacheValue(key, value, false, true)
+
+	if len(store.cache) >= 5012 {
+		store.Write()
+	}
 }
 
 // Has implements types.KVStore.
@@ -235,6 +239,7 @@ func (store *Store) clearUnsortedCacheSubset(unsorted []*kv.Pair) {
 		}
 	}
 
+	// push remaining unsorted items to end of sortedCache
 	for _, kvp := range unsorted {
 		store.sortedCache.PushBack(kvp)
 	}

--- a/store/cachekv/store_test.go
+++ b/store/cachekv/store_test.go
@@ -354,23 +354,28 @@ func doRandomOp(t *testing.T, st types.CacheKVStore, truth dbm.DB, maxKey int) {
 	switch r {
 	case opSet:
 		k := randInt(maxKey)
+		fmt.Println("opSet", k)
 		st.Set(keyFmt(k), valFmt(k))
 		err := truth.Set(keyFmt(k), valFmt(k))
 		require.NoError(t, err)
 	case opSetRange:
 		start := randInt(maxKey - 2)
 		end := randInt(maxKey-start) + start
+		fmt.Println("opSetRange", start, end)
 		setRange(t, st, truth, start, end)
 	case opDel:
 		k := randInt(maxKey)
+		fmt.Println("opDel", k)
 		st.Delete(keyFmt(k))
 		err := truth.Delete(keyFmt(k))
 		require.NoError(t, err)
 	case opDelRange:
 		start := randInt(maxKey - 2)
 		end := randInt(maxKey-start) + start
+		fmt.Println("opDelRange", start, end)
 		deleteRange(t, st, truth, start, end)
 	case opWrite:
+		fmt.Println("opWrite")
 		st.Write()
 	}
 }


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

The cache KV store has significant performance issues with creating iterators when the cache is mediumly large.
Every item thats in the cache effectively got compared to the iterator start and end range, meaning that doing `O(N)` state writes and iterator creations would take `O(N^2)` time.

This non-breaking patch improves the osmosis upgrade time by 3x. The current algorithms are probably better at very small cache sizes, hence everything is size gated. I imagine this should then be a strict improvement, but this is not benchmarked.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)