### PR TITLE
Add HasAccount to the AuthKeeper to save protobuf decoding time

### DIFF
--- a/x/auth/keeper/account.go
+++ b/x/auth/keeper/account.go
@@ -25,6 +25,17 @@ func (ak AccountKeeper) NewAccount(ctx sdk.Context, acc types.AccountI) types.Ac
 	return acc
 }
 
+// HasAccount implements AccountKeeperI.
+func (ak AccountKeeper) HasAccount(ctx sdk.Context, addr sdk.AccAddress) bool {
+	store := ctx.KVStore(ak.key)
+	bz := store.Get(types.AddressStoreKey(addr))
+	if bz == nil {
+		return false
+	}
+
+	return true
+}
+
 // GetAccount implements AccountKeeperI.
 func (ak AccountKeeper) GetAccount(ctx sdk.Context, addr sdk.AccAddress) types.AccountI {
 	store := ctx.KVStore(ak.key)

--- a/x/auth/keeper/keeper.go
+++ b/x/auth/keeper/keeper.go
@@ -25,6 +25,9 @@ type AccountKeeperI interface {
 	// Retrieve an account from the store.
 	GetAccount(sdk.Context, sdk.AccAddress) types.AccountI
 
+	// Check if an account exists in the store.
+	HasAccount(sdk.Context, sdk.AccAddress) bool
+
 	// Set an account in the store.
 	SetAccount(sdk.Context, types.AccountI)
 

--- a/x/bank/keeper/send.go
+++ b/x/bank/keeper/send.go
@@ -125,8 +125,8 @@ func (k BaseSendKeeper) InputOutputCoins(ctx sdk.Context, inputs []types.Input, 
 		//
 		// NOTE: This should ultimately be removed in favor a more flexible approach
 		// such as delegated fee messages.
-		acc := k.ak.GetAccount(ctx, outAddress)
-		if acc == nil {
+		accExists := k.ak.HasAccount(ctx, outAddress)
+		if !accExists {
 			defer telemetry.IncrCounter(1, "new", "account")
 			k.ak.SetAccount(ctx, k.ak.NewAccountWithAddress(ctx, outAddress))
 		}
@@ -165,8 +165,8 @@ func (k BaseSendKeeper) SendCoins(ctx sdk.Context, fromAddr sdk.AccAddress, toAd
 	//
 	// NOTE: This should ultimately be removed in favor a more flexible approach
 	// such as delegated fee messages.
-	acc := k.ak.GetAccount(ctx, toAddr)
-	if acc == nil {
+	accExists := k.ak.HasAccount(ctx, toAddr)
+	if !accExists {
 		defer telemetry.IncrCounter(1, "new", "account")
 		k.ak.SetAccount(ctx, k.ak.NewAccountWithAddress(ctx, toAddr))
 	}

--- a/x/bank/types/expected_keepers.go
+++ b/x/bank/types/expected_keepers.go
@@ -13,6 +13,7 @@ type AccountKeeper interface {
 
 	GetAccount(ctx sdk.Context, addr sdk.AccAddress) types.AccountI
 	GetAllAccounts(ctx sdk.Context) []types.AccountI
+	HasAccount(ctx sdk.Context, addr sdk.AccAddress) bool
 	SetAccount(ctx sdk.Context, acc types.AccountI)
 
 	IterateAccounts(ctx sdk.Context, process func(types.AccountI) bool)


### PR DESCRIPTION
We found in the Osmosis epoch time, the many accesses to GetAccount's proto unmarshalling was a significant slowdown.
This adds a HasAccount method to the AuthKeeper, and fixes one unnecessary GetAccount which it appears within SendCoins, which was showing up as notable in our epoch time profiling. (Estimated ~6% of benchmark's epoch time)


---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
