### PR TITLE
Comment out the send event used during the epoch (v4)

### DIFF
--- a/x/bank/keeper/send.go
+++ b/x/bank/keeper/send.go
@@ -209,12 +209,12 @@ func (k BaseSendKeeper) SendManyCoins(ctx sdk.Context, fromAddr sdk.AccAddress, 
 			k.ak.SetAccount(ctx, k.ak.NewAccountWithAddress(ctx, toAddr))
 		}
 
-		ctx.EventManager().EmitEvent(sdk.NewEvent(
-			types.EventTypeTransfer,
-			sdk.NewAttribute(types.AttributeKeyRecipient, toAddr.String()),
-			sdk.NewAttribute(types.AttributeKeySender, fromAddrString),
-			sdk.NewAttribute(sdk.AttributeKeyAmount, amt.String()),
-		))
+		// ctx.EventManager().EmitEvent(sdk.NewEvent(
+		// 	types.EventTypeTransfer,
+		// 	sdk.NewAttribute(types.AttributeKeyRecipient, toAddr.String()),
+		// 	sdk.NewAttribute(types.AttributeKeySender, fromAddrString),
+		// 	sdk.NewAttribute(sdk.AttributeKeyAmount, amt.String()),
+		// ))
 	}
 
 	ctx.EventManager().EmitEvent(sdk.NewEvent(


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Comments out the linear amount of events for Sends during the epoch block in Osmosis. I know Sunny didn't want this change, out of fears of what 'dumb' wallets may subscribe to for monitoring their balance, but I think this is necessary for performance alleviation until more fixes to the event system land.

(However, this information is still conveyed via the liquidity add events state machine side)

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
