### PR TITLE
fix: Update store.go

### DIFF
--- a/store/cache/cache.go
+++ b/store/cache/cache.go
@@ -15,7 +15,7 @@ var (
 
 	// DefaultCommitKVStoreCacheSize defines the persistent ARC cache size for a
 	// CommitKVStoreCache.
-	DefaultCommitKVStoreCacheSize uint = 1000
+	DefaultCommitKVStoreCacheSize uint = 100000
 )
 
 type (

--- a/store/iavl/store.go
+++ b/store/iavl/store.go
@@ -21,8 +21,10 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/kv"
 )
 
+
+// I know this seems like a lot, but we were very successful relaying with this setting. We were also very successful validating with this setting: no more epoch pause at all.
 const (
-	defaultIAVLCacheSize = 1500000
+	defaultIAVLCacheSize = 10000000
 )
 
 var (

--- a/store/iavl/store.go
+++ b/store/iavl/store.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	defaultIAVLCacheSize = 500000
+	defaultIAVLCacheSize = 1500000
 )
 
 var (


### PR DESCRIPTION
Our relayer started working much better with values like these.  I suggest that for now, we make this the default. 

I think it would reduce epoch times, too. 

Also, this won't cause linear increases in memory consumption, but I don't know why that is.  My nodes tend to level out at around 40gb.  I'd recommend 64gb of ram for people using this and since a validator could just like:

4 or 8 core consumer cpu
1.8t samsung 980pro
64gb ram

I reckon for about a thousand bucks, once, seems a real nice way to both fully eliminate the epoch time meltdown issue and decentralize the validator set. 