### PR TITLE
feat: Add safety check: restriction fn in bank module for mint perms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -290,6 +290,7 @@ Security Release. No breaking changes related to 0.44.x.
 * [\#9428](https://github.com/cosmos/cosmos-sdk/pull/9428) Optimize bank InitGenesis. Added `k.initBalances`.
 * [\#9429](https://github.com/cosmos/cosmos-sdk/pull/9429) Add `cosmos_sdk_version` to node_info
 * [\#9541](https://github.com/cosmos/cosmos-sdk/pull/9541) Bump tendermint dependency to v0.34.11.
+* (x/bank) [\#10771](https://github.com/cosmos/cosmos-sdk/pull/10771) Add safety check on bank module perms to allow module-specific mint restrictions (e.g. only minting a certain denom).
 
 ### Bug Fixes
 

--- a/x/bank/keeper/keeper.go
+++ b/x/bank/keeper/keeper.go
@@ -20,6 +20,7 @@ var _ Keeper = (*BaseKeeper)(nil)
 // between accounts.
 type Keeper interface {
 	SendKeeper
+	WithMintCoinsRestriction(BankMintingRestrictionFn) BaseKeeper
 
 	InitGenesis(sdk.Context, *types.GenesisState)
 	ExportGenesis(sdk.Context) *types.GenesisState
@@ -52,11 +53,14 @@ type Keeper interface {
 type BaseKeeper struct {
 	BaseSendKeeper
 
-	ak         types.AccountKeeper
-	cdc        codec.BinaryCodec
-	storeKey   sdk.StoreKey
-	paramSpace paramtypes.Subspace
+	ak                     types.AccountKeeper
+	cdc                    codec.BinaryCodec
+	storeKey               sdk.StoreKey
+	paramSpace             paramtypes.Subspace
+	mintCoinsRestrictionFn BankMintingRestrictionFn
 }
+
+type BankMintingRestrictionFn func(ctx sdk.Context, coins sdk.Coins) error
 
 // GetPaginatedTotalSupply queries for the supply, ignoring 0 coins, with a given pagination
 func (k BaseKeeper) GetPaginatedTotalSupply(ctx sdk.Context, pagination *query.PageRequest) (sdk.Coins, *query.PageResponse, error) {
@@ -104,12 +108,32 @@ func NewBaseKeeper(
 	}
 
 	return BaseKeeper{
-		BaseSendKeeper: NewBaseSendKeeper(cdc, storeKey, ak, paramSpace, blockedAddrs),
-		ak:             ak,
-		cdc:            cdc,
-		storeKey:       storeKey,
-		paramSpace:     paramSpace,
+		BaseSendKeeper:         NewBaseSendKeeper(cdc, storeKey, ak, paramSpace, blockedAddrs),
+		ak:                     ak,
+		cdc:                    cdc,
+		storeKey:               storeKey,
+		paramSpace:             paramSpace,
+		mintCoinsRestrictionFn: func(ctx sdk.Context, coins sdk.Coins) error { return nil },
 	}
+}
+
+// WithMintCoinsRestriction restricts the bank Keeper used within a specific module to
+// have restricted permissions on minting speicified denoms.
+func (k BaseKeeper) WithMintCoinsRestriction(NewRestrictionFn BankMintingRestrictionFn) BaseKeeper {
+	// this allows nesting restriction functions
+	oldRestrictionFn := k.mintCoinsRestrictionFn
+	k.mintCoinsRestrictionFn = func(ctx sdk.Context, coins sdk.Coins) error {
+		err := NewRestrictionFn(ctx, coins)
+		if err != nil {
+			return err
+		}
+		err = oldRestrictionFn(ctx, coins)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+	return k
 }
 
 // DelegateCoins performs delegation by deducting amt coins from an account with
@@ -391,6 +415,11 @@ func (k BaseKeeper) UndelegateCoinsFromModuleToAccount(
 // MintCoins creates new coins from thin air and adds it to the module account.
 // It will panic if the module account does not exist or is unauthorized.
 func (k BaseKeeper) MintCoins(ctx sdk.Context, moduleName string, amounts sdk.Coins) error {
+	err := k.mintCoinsRestrictionFn(ctx, amounts)
+	if err != nil {
+		ctx.Logger().Error(fmt.Sprintf("Module %s attempted minting coins %s it did not have permission for with error %v", moduleName, amounts, err))
+		return err
+	}
 	acc := k.ak.GetModuleAccount(ctx, moduleName)
 	if acc == nil {
 		panic(sdkerrors.Wrapf(sdkerrors.ErrUnknownAddress, "module account %s does not exist", moduleName))
@@ -400,7 +429,7 @@ func (k BaseKeeper) MintCoins(ctx sdk.Context, moduleName string, amounts sdk.Co
 		panic(sdkerrors.Wrapf(sdkerrors.ErrUnauthorized, "module account %s does not have permissions to mint tokens", moduleName))
 	}
 
-	err := k.addCoins(ctx, acc.GetAddress(), amounts)
+	err = k.addCoins(ctx, acc.GetAddress(), amounts)
 	if err != nil {
 		return err
 	}

--- a/x/bank/keeper/keeper_test.go
+++ b/x/bank/keeper/keeper_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -1218,6 +1219,75 @@ func (suite *IntegrationTestSuite) getTestMetadata() []types.Metadata {
 			Base:    "utoken",
 			Display: "token",
 		},
+	}
+}
+
+func (suite *IntegrationTestSuite) TestMintCoinRestrictions() {
+	type BankMintingRestrictionFn func(ctx sdk.Context, coins sdk.Coins) error
+
+	maccPerms := simapp.GetMaccPerms()
+	maccPerms[multiPerm] = []string{authtypes.Burner, authtypes.Minter, authtypes.Staking}
+
+	suite.app.AccountKeeper = authkeeper.NewAccountKeeper(
+		suite.app.AppCodec(), suite.app.GetKey(authtypes.StoreKey), suite.app.GetSubspace(authtypes.ModuleName),
+		authtypes.ProtoBaseAccount, maccPerms)
+	suite.app.AccountKeeper.SetModuleAccount(suite.ctx, multiPermAcc)
+
+	type testCase struct {
+		coinsToTry sdk.Coin
+		expectPass bool
+	}
+
+	tests := []struct {
+		name          string
+		restrictionFn BankMintingRestrictionFn
+		testCases     []testCase
+	}{
+		{
+			"restriction",
+			func(ctx sdk.Context, coins sdk.Coins) error {
+				for _, coin := range coins {
+					if coin.Denom != fooDenom {
+						return fmt.Errorf("Module %s only has perms for minting %s coins, tried minting %s coins", types.ModuleName, fooDenom, coin.Denom)
+					}
+				}
+				return nil
+			},
+			[]testCase{
+				{
+					coinsToTry: newFooCoin(100),
+					expectPass: true,
+				},
+				{
+					coinsToTry: newBarCoin(100),
+					expectPass: false,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		suite.app.BankKeeper = keeper.NewBaseKeeper(suite.app.AppCodec(), suite.app.GetKey(types.StoreKey),
+			suite.app.AccountKeeper, suite.app.GetSubspace(types.ModuleName), nil).WithMintCoinsRestriction(keeper.BankMintingRestrictionFn(test.restrictionFn))
+		for _, testCase := range test.testCases {
+			if testCase.expectPass {
+				suite.Require().NoError(
+					suite.app.BankKeeper.MintCoins(
+						suite.ctx,
+						multiPermAcc.Name,
+						sdk.NewCoins(testCase.coinsToTry),
+					),
+				)
+			} else {
+				suite.Require().Error(
+					suite.app.BankKeeper.MintCoins(
+						suite.ctx,
+						multiPermAcc.Name,
+						sdk.NewCoins(testCase.coinsToTry),
+					),
+				)
+			}
+		}
 	}
 }
 

--- a/x/bank/spec/02_keepers.md
+++ b/x/bank/spec/02_keepers.md
@@ -54,11 +54,14 @@ message Output {
 
 The base keeper provides full-permission access: the ability to arbitrary modify any account's balance and mint or burn coins.
 
+Restricted permission to mint per module could be achieved by using baseKeeper with `WithMintCoinsRestriction` to give specific restrictions to mint (e.g. only minting certain denom).
+
 ```go
 // Keeper defines a module interface that facilitates the transfer of coins
 // between accounts.
 type Keeper interface {
     SendKeeper
+    WithMintCoinsRestriction(NewRestrictionFn BankMintingRestrictionFn) BaseKeeper 
 
     InitGenesis(sdk.Context, *types.GenesisState)
     ExportGenesis(sdk.Context) *types.GenesisState


### PR DESCRIPTION
## Description

Closes: https://github.com/osmosis-labs/cosmos-sdk/issues/48


This PR adds feature to the bank module so that other modules using bankKeeper would be able to call the keeper with restricted permissions when minting coins. `WithMintCoinsRestriction` would be able to get called within app.go when setting keeper components for each individual keeper, taking a function that would validate minting denom as an argument.

The example below demonstrates adding bank module with restricted permissions.
```
	app.DistrKeeper = distrkeeper.NewKeeper(
		appCodec, keys[distrtypes.StoreKey], app.GetSubspace(distrtypes.ModuleName), app.AccountKeeper, app.BankKeeper.WithMintCoinsRestriction(DistributionMintingRestriction),
		&stakingKeeper, authtypes.FeeCollectorName, app.ModuleAccountAddrs(),
	)
```
while there would be a seperate function that would restrict and validate allowed denoms as such.

```

func DistributionMintingRestriction(ctx sdk.Context, coins sdk.Coins) errors {
  for _, coin := range coins {
    if coin.Denom != ctx.NativeStakingDenom {
       return errors.New(fmt.Sprintf("Distribution can only print denom %s, tried minting %s", ctx.NativeStakingDenom, coin.Denom))
     }
  }
}
```

The sdk's simapp currently does not have any keepers that are to be changed with this implementation added, thus remaining unchanged in `app.go`.


Originally from: https://github.com/cosmos/cosmos-sdk/pull/10771

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)