### PR TITLE
fix: Change default pruning options

### DIFF
--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -20,15 +20,18 @@ const DefaultConfigTemplate = `# This is a TOML config file.
 # specified in this config (e.g. 0.25token1;0.0001token2).
 minimum-gas-prices = "{{ .BaseConfig.MinGasPrices }}"
 
-# default: only the last 10000 states(approximately 1 week worth of state) are kept; pruning at 10 block intervals
+# default: only the last 100,000 states(approximately 1 week worth of state) are kept; pruning at 100 block intervals
 # nothing: all historic states will be saved, nothing will be deleted (i.e. archiving node)
-# everything: all saved states will be deleted, storing only the current state; pruning at 10 block intervals
+# everything: all saved states will be deleted, storing only the current state; pruning at 10 block intervals.
 # custom: allow pruning options to be manually specified through 'pruning-keep-recent', 'pruning-keep-every', and 'pruning-interval'
 pruning = "{{ .BaseConfig.Pruning }}"
 
 # These are applied if and only if the pruning strategy is custom.
+# pruning-keep-recent = N means keep all of the last N states
 pruning-keep-recent = "{{ .BaseConfig.PruningKeepRecent }}"
+# pruning-keep-every = N means keep every Nth state, in addition to keep-recent
 pruning-keep-every = "{{ .BaseConfig.PruningKeepEvery }}"
+# pruning-interval = N means we delete old states from disk every Nth block.
 pruning-interval = "{{ .BaseConfig.PruningInterval }}"
 
 # HaltHeight contains a non-zero block height at which a node will gracefully

--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -20,7 +20,7 @@ const DefaultConfigTemplate = `# This is a TOML config file.
 # specified in this config (e.g. 0.25token1;0.0001token2).
 minimum-gas-prices = "{{ .BaseConfig.MinGasPrices }}"
 
-# default: the last 100 states are kept in addition to every 500th state; pruning at 10 block intervals
+# default: only the last 10000 states are kept; pruning at 10 block intervals
 # nothing: all historic states will be saved, nothing will be deleted (i.e. archiving node)
 # everything: all saved states will be deleted, storing only the current state; pruning at 10 block intervals
 # custom: allow pruning options to be manually specified through 'pruning-keep-recent', 'pruning-keep-every', and 'pruning-interval'

--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -20,7 +20,7 @@ const DefaultConfigTemplate = `# This is a TOML config file.
 # specified in this config (e.g. 0.25token1;0.0001token2).
 minimum-gas-prices = "{{ .BaseConfig.MinGasPrices }}"
 
-# default: only the last 10000 states are kept; pruning at 10 block intervals
+# default: only the last 10000 states(approximately 1 week worth of state) are kept; pruning at 10 block intervals
 # nothing: all historic states will be saved, nothing will be deleted (i.e. archiving node)
 # everything: all saved states will be deleted, storing only the current state; pruning at 10 block intervals
 # custom: allow pruning options to be manually specified through 'pruning-keep-recent', 'pruning-keep-every', and 'pruning-interval'

--- a/server/start.go
+++ b/server/start.go
@@ -86,7 +86,7 @@ Pruning options can be provided via the '--pruning' flag or alternatively with '
 
 For '--pruning' the options are as follows:
 
-default: only the last 10000 states are kept; pruning at 10 block intervals
+default: only the last 100000 states(approximately 1 week worth of state) are kept; pruning at 10 block intervals
 nothing: all historic states will be saved, nothing will be deleted (i.e. archiving node)
 everything: all saved states will be deleted, storing only the current state; pruning at 10 block intervals
 custom: allow pruning options to be manually specified through 'pruning-keep-recent', 'pruning-keep-every', and 'pruning-interval'

--- a/server/start.go
+++ b/server/start.go
@@ -86,7 +86,7 @@ Pruning options can be provided via the '--pruning' flag or alternatively with '
 
 For '--pruning' the options are as follows:
 
-default: the last 100 states are kept in addition to every 500th state; pruning at 10 block intervals
+default: only the last 10000 states are kept; pruning at 10 block intervals
 nothing: all historic states will be saved, nothing will be deleted (i.e. archiving node)
 everything: all saved states will be deleted, storing only the current state; pruning at 10 block intervals
 custom: allow pruning options to be manually specified through 'pruning-keep-recent', 'pruning-keep-every', and 'pruning-interval'

--- a/server/start.go
+++ b/server/start.go
@@ -86,7 +86,7 @@ Pruning options can be provided via the '--pruning' flag or alternatively with '
 
 For '--pruning' the options are as follows:
 
-default: only the last 100000 states(approximately 1 week worth of state) are kept; pruning at 10 block intervals
+default: only the last 100,000 states(approximately 1 week worth of state) are kept; pruning at 100 block intervals
 nothing: all historic states will be saved, nothing will be deleted (i.e. archiving node)
 everything: all saved states will be deleted, storing only the current state; pruning at 10 block intervals
 custom: allow pruning options to be manually specified through 'pruning-keep-recent', 'pruning-keep-every', and 'pruning-interval'

--- a/store/types/pruning.go
+++ b/store/types/pruning.go
@@ -11,12 +11,12 @@ const (
 )
 
 var (
-	// PruneDefault defines a pruning strategy where the last 10000 heights are
+	// PruneDefault defines a pruning strategy where the last 100000 heights are
 	// kept where to-be pruned heights are pruned at every 10th height.
-	// The last 10000 heights are kept assuming the typical
+	// The last 100000 heights are kept(approximately 1 week worth of state) assuming the typical
 	// block time is 5s and typical unbonding period is 21 days. If these values
 	// do not match the applications' requirements, use the "custom" option.
-	PruneDefault = NewPruningOptions(10000, 0, 10)
+	PruneDefault = NewPruningOptions(100000, 0, 10)
 
 	// PruneEverything defines a pruning strategy where all committed heights are
 	// deleted, storing only the current height and where to-be pruned heights are

--- a/store/types/pruning.go
+++ b/store/types/pruning.go
@@ -11,17 +11,17 @@ const (
 )
 
 var (
-	// PruneDefault defines a pruning strategy where the last 100000 heights are
+	// PruneDefault defines a pruning strategy where the last 100,000 heights are
 	// kept where to-be pruned heights are pruned at every 10th height.
 	// The last 100000 heights are kept(approximately 1 week worth of state) assuming the typical
-	// block time is 5s and typical unbonding period is 21 days. If these values
+	// block time is 6s. If these values
 	// do not match the applications' requirements, use the "custom" option.
-	PruneDefault = NewPruningOptions(100000, 0, 10)
+	PruneDefault = NewPruningOptions(100_000, 0, 100)
 
 	// PruneEverything defines a pruning strategy where all committed heights are
-	// deleted, storing only the current height and where to-be pruned heights are
+	// deleted, storing only the current height and last 10 states. To-be pruned heights are
 	// pruned at every 10th height.
-	PruneEverything = NewPruningOptions(0, 0, 10)
+	PruneEverything = NewPruningOptions(10, 0, 10)
 
 	// PruneNothing defines a pruning strategy where all heights are kept on disk.
 	PruneNothing = NewPruningOptions(0, 1, 0)

--- a/store/types/pruning.go
+++ b/store/types/pruning.go
@@ -11,12 +11,12 @@ const (
 )
 
 var (
-	// PruneDefault defines a pruning strategy where the last 362880 heights are
-	// kept in addition to every 100th and where to-be pruned heights are pruned
-	// at every 10th height. The last 362880 heights are kept assuming the typical
+	// PruneDefault defines a pruning strategy where the last 10000 heights are
+	// kept where to-be pruned heights are pruned at every 10th height.
+	// The last 10000 heights are kept assuming the typical
 	// block time is 5s and typical unbonding period is 21 days. If these values
 	// do not match the applications' requirements, use the "custom" option.
-	PruneDefault = NewPruningOptions(362880, 100, 10)
+	PruneDefault = NewPruningOptions(10000, 0, 10)
 
 	// PruneEverything defines a pruning strategy where all committed heights are
 	// deleted, storing only the current height and where to-be pruned heights are


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Current default pruning options keep every 100th height in addition to the latest 362880 heights, which in most cases have no need to keep this much, unless a node wants to run historical queries. This should not be the default case- this PR suggests an override in the default pruning settings as the following:

- keep-recent = 100000
- keep-every = 0
- Interval = 10

Additionally, a significant docs mismatch has been underlying for default pruning options, where keep-every was 100, not 500 as stated.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)