### PR TITLE
fix: Stop bank migration panic in tests

### DIFF
--- a/x/bank/legacy/v043/store.go
+++ b/x/bank/legacy/v043/store.go
@@ -1,8 +1,6 @@
 package v043
 
 import (
-	"fmt"
-
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -86,7 +84,11 @@ func migrateBalanceKeys(store sdk.KVStore) {
 			addr = sdk.AccAddress(oldKey[:32])
 			addrLen = 32
 		} else {
-			panic(fmt.Sprintf("We have an issue ser, oldkey %v, len %d", oldKey, len(oldKey)))
+			// We remove the panic because this worked through the Osmosis v5 upgrade.
+			// This was causing issues in tests, so we just assume the tests test the default SDK code, at 20 bytes.
+			// panic(fmt.Sprintf("We have an issue ser, oldkey %v, len %d", oldKey, len(oldKey)))
+			addr = v040bank.AddressFromBalancesStore(oldStoreIter.Key())
+			addrLen = v040auth.AddrLen
 		}
 		denom := oldStoreIter.Key()[addrLen:]
 		newStoreKey := append(types.CreateAccountBalancesPrefix(addr), denom...)


### PR DESCRIPTION
TL;DR because in osmosis we had 32 byte module accoutns pre SDK v0.44, we had to make custom migration code. Our custom migration code was doing something hacky, which caused a panic in a scenario that wouldn't get hit on-chain.(but the panic was there to sanity check this)

This however does get triggered in tests, hence its causing some tests to fail.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)