### PR TITLE
Update slashing hooks

### DIFF
--- a/x/distribution/keeper/hooks.go
+++ b/x/distribution/keeper/hooks.go
@@ -97,16 +97,8 @@ func (h Hooks) AfterDelegationModified(ctx sdk.Context, delAddr sdk.AccAddress, 
 }
 
 // record the slash event
-func (h Hooks) BeforeValidatorSlashed(ctx sdk.Context, valAddr sdk.ValAddress, fraction sdk.Dec) {
+func (h Hooks) BeforeValidatorSlashed(ctx sdk.Context, valAddr sdk.ValAddress, slashHeight int64, fraction sdk.Dec) {
 	h.k.updateValidatorSlashFraction(ctx, valAddr, fraction)
-}
-
-func (h Hooks) BeforeSlashingUnbondingDelegation(ctx sdk.Context, unbondingDelegation stakingtypes.UnbondingDelegation,
-	infractionHeight int64, slashFactor sdk.Dec) {
-}
-
-func (h Hooks) BeforeSlashingRedelegation(ctx sdk.Context, srcValidator stakingtypes.Validator, redelegation stakingtypes.Redelegation,
-	infractionHeight int64, slashFactor sdk.Dec) {
 }
 
 func (h Hooks) BeforeValidatorModified(_ sdk.Context, _ sdk.ValAddress)                         {}

--- a/x/distribution/keeper/hooks.go
+++ b/x/distribution/keeper/hooks.go
@@ -97,8 +97,11 @@ func (h Hooks) AfterDelegationModified(ctx sdk.Context, delAddr sdk.AccAddress, 
 }
 
 // record the slash event
-func (h Hooks) BeforeValidatorSlashed(ctx sdk.Context, valAddr sdk.ValAddress, slashHeight int64, fraction sdk.Dec) {
-	h.k.updateValidatorSlashFraction(ctx, valAddr, fraction)
+// distribution only cares about the 'effective slash factor', not the 'actual slash factor'.
+// This is due to {details} of what it wants to be tracking.
+// TODO: Can effective slash factor be calculated in distribution? Would simplify the hook.
+func (h Hooks) BeforeValidatorSlashed(ctx sdk.Context, valAddr sdk.ValAddress, slashHeight int64, slashFactor sdk.Dec, effectiveSlashFactor sdk.Dec) {
+	h.k.updateValidatorSlashFraction(ctx, valAddr, effectiveSlashFactor)
 }
 
 func (h Hooks) BeforeValidatorModified(_ sdk.Context, _ sdk.ValAddress)                         {}

--- a/x/distribution/types/expected_keepers.go
+++ b/x/distribution/types/expected_keepers.go
@@ -75,5 +75,5 @@ type StakingHooks interface {
 	BeforeDelegationCreated(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress)        // Must be called when a delegation is created
 	BeforeDelegationSharesModified(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) // Must be called when a delegation's shares are modified
 	AfterDelegationModified(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress)
-	BeforeValidatorSlashed(ctx sdk.Context, valAddr sdk.ValAddress, fraction sdk.Dec)
+	BeforeValidatorSlashed(ctx sdk.Context, valAddr sdk.ValAddress, infractionHeight int64, fraction sdk.Dec)
 }

--- a/x/slashing/keeper/hooks.go
+++ b/x/slashing/keeper/hooks.go
@@ -75,4 +75,5 @@ func (h Hooks) BeforeDelegationCreated(_ sdk.Context, _ sdk.AccAddress, _ sdk.Va
 func (h Hooks) BeforeDelegationSharesModified(_ sdk.Context, _ sdk.AccAddress, _ sdk.ValAddress) {}
 func (h Hooks) BeforeDelegationRemoved(_ sdk.Context, _ sdk.AccAddress, _ sdk.ValAddress)        {}
 func (h Hooks) AfterDelegationModified(_ sdk.Context, _ sdk.AccAddress, _ sdk.ValAddress)        {}
-func (h Hooks) BeforeValidatorSlashed(_ sdk.Context, _ sdk.ValAddress, _ int64, _ sdk.Dec)       {}
+func (h Hooks) BeforeValidatorSlashed(_ sdk.Context, _ sdk.ValAddress, _ int64, _ sdk.Dec, _ sdk.Dec) {
+}

--- a/x/slashing/keeper/hooks.go
+++ b/x/slashing/keeper/hooks.go
@@ -7,7 +7,6 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/slashing/types"
-	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
 func (k Keeper) AfterValidatorBonded(ctx sdk.Context, address sdk.ConsAddress, _ sdk.ValAddress) {
@@ -76,11 +75,4 @@ func (h Hooks) BeforeDelegationCreated(_ sdk.Context, _ sdk.AccAddress, _ sdk.Va
 func (h Hooks) BeforeDelegationSharesModified(_ sdk.Context, _ sdk.AccAddress, _ sdk.ValAddress) {}
 func (h Hooks) BeforeDelegationRemoved(_ sdk.Context, _ sdk.AccAddress, _ sdk.ValAddress)        {}
 func (h Hooks) AfterDelegationModified(_ sdk.Context, _ sdk.AccAddress, _ sdk.ValAddress)        {}
-func (h Hooks) BeforeValidatorSlashed(_ sdk.Context, _ sdk.ValAddress, _ sdk.Dec)                {}
-func (h Hooks) BeforeSlashingUnbondingDelegation(ctx sdk.Context, unbondingDelegation stakingtypes.UnbondingDelegation,
-	infractionHeight int64, slashFactor sdk.Dec) {
-}
-
-func (h Hooks) BeforeSlashingRedelegation(ctx sdk.Context, srcValidator stakingtypes.Validator, redelegation stakingtypes.Redelegation,
-	infractionHeight int64, slashFactor sdk.Dec) {
-}
+func (h Hooks) BeforeValidatorSlashed(_ sdk.Context, _ sdk.ValAddress, _ int64, _ sdk.Dec)       {}

--- a/x/staking/keeper/hooks.go
+++ b/x/staking/keeper/hooks.go
@@ -72,8 +72,8 @@ func (k Keeper) AfterDelegationModified(ctx sdk.Context, delAddr sdk.AccAddress,
 }
 
 // BeforeValidatorSlashed - call hook if registered
-func (k Keeper) BeforeValidatorSlashed(ctx sdk.Context, valAddr sdk.ValAddress, slashHeight int64, fraction sdk.Dec) {
+func (k Keeper) BeforeValidatorSlashed(ctx sdk.Context, valAddr sdk.ValAddress, slashHeight int64, slashFactor sdk.Dec, effectiveSlashFactor sdk.Dec) {
 	if k.hooks != nil {
-		k.hooks.BeforeValidatorSlashed(ctx, valAddr, slashHeight, fraction)
+		k.hooks.BeforeValidatorSlashed(ctx, valAddr, slashHeight, slashFactor, effectiveSlashFactor)
 	}
 }

--- a/x/staking/keeper/hooks.go
+++ b/x/staking/keeper/hooks.go
@@ -72,24 +72,8 @@ func (k Keeper) AfterDelegationModified(ctx sdk.Context, delAddr sdk.AccAddress,
 }
 
 // BeforeValidatorSlashed - call hook if registered
-func (k Keeper) BeforeValidatorSlashed(ctx sdk.Context, valAddr sdk.ValAddress, fraction sdk.Dec) {
+func (k Keeper) BeforeValidatorSlashed(ctx sdk.Context, valAddr sdk.ValAddress, slashHeight int64, fraction sdk.Dec) {
 	if k.hooks != nil {
-		k.hooks.BeforeValidatorSlashed(ctx, valAddr, fraction)
-	}
-}
-
-// BeforeSlashingUnbondingDelegation - call hook if registered
-func (k Keeper) BeforeSlashingUnbondingDelegation(ctx sdk.Context, unbondingDelegation types.UnbondingDelegation,
-	infractionHeight int64, slashFactor sdk.Dec) {
-	if k.hooks != nil {
-		k.hooks.BeforeSlashingUnbondingDelegation(ctx, unbondingDelegation, infractionHeight, slashFactor)
-	}
-}
-
-// BeforeSlashingRedelegation - call hook if registered
-func (k Keeper) BeforeSlashingRedelegation(ctx sdk.Context, srcValidator types.Validator, redelegation types.Redelegation,
-	infractionHeight int64, slashFactor sdk.Dec) {
-	if k.hooks != nil {
-		k.hooks.BeforeSlashingRedelegation(ctx, srcValidator, redelegation, infractionHeight, slashFactor)
+		k.hooks.BeforeValidatorSlashed(ctx, valAddr, slashHeight, fraction)
 	}
 }

--- a/x/staking/keeper/slash.go
+++ b/x/staking/keeper/slash.go
@@ -114,7 +114,7 @@ func (k Keeper) Slash(ctx sdk.Context, consAddr sdk.ConsAddress, infractionHeigh
 			effectiveFraction = sdk.OneDec()
 		}
 		// call the before-slashed hook
-		k.BeforeValidatorSlashed(ctx, operatorAddress, infractionHeight, effectiveFraction)
+		k.BeforeValidatorSlashed(ctx, operatorAddress, infractionHeight, slashFactor, effectiveFraction)
 	}
 
 	// Deduct from validator's bonded tokens and update the validator.

--- a/x/staking/keeper/slash.go
+++ b/x/staking/keeper/slash.go
@@ -114,7 +114,7 @@ func (k Keeper) Slash(ctx sdk.Context, consAddr sdk.ConsAddress, infractionHeigh
 			effectiveFraction = sdk.OneDec()
 		}
 		// call the before-slashed hook
-		k.BeforeValidatorSlashed(ctx, operatorAddress, effectiveFraction)
+		k.BeforeValidatorSlashed(ctx, operatorAddress, infractionHeight, effectiveFraction)
 	}
 
 	// Deduct from validator's bonded tokens and update the validator.
@@ -165,8 +165,6 @@ func (k Keeper) Unjail(ctx sdk.Context, consAddr sdk.ConsAddress) {
 // insufficient stake remaining)
 func (k Keeper) SlashUnbondingDelegation(ctx sdk.Context, unbondingDelegation types.UnbondingDelegation,
 	infractionHeight int64, slashFactor sdk.Dec) (totalSlashAmount sdk.Int) {
-	// hook before slashing unbonding delegation
-	k.BeforeSlashingUnbondingDelegation(ctx, unbondingDelegation, infractionHeight, slashFactor)
 
 	now := ctx.BlockHeader().Time
 	totalSlashAmount = sdk.ZeroInt()
@@ -221,8 +219,6 @@ func (k Keeper) SlashUnbondingDelegation(ctx sdk.Context, unbondingDelegation ty
 // NOTE this is only slashing for prior infractions from the source validator
 func (k Keeper) SlashRedelegation(ctx sdk.Context, srcValidator types.Validator, redelegation types.Redelegation,
 	infractionHeight int64, slashFactor sdk.Dec) (totalSlashAmount sdk.Int) {
-	// hook before slashing redelegation
-	k.BeforeSlashingRedelegation(ctx, srcValidator, redelegation, infractionHeight, slashFactor)
 
 	now := ctx.BlockHeader().Time
 	totalSlashAmount = sdk.ZeroInt()

--- a/x/staking/types/expected_keepers.go
+++ b/x/staking/types/expected_keepers.go
@@ -100,9 +100,5 @@ type StakingHooks interface {
 	BeforeDelegationSharesModified(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) // Must be called when a delegation's shares are modified
 	BeforeDelegationRemoved(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress)        // Must be called when a delegation is removed
 	AfterDelegationModified(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress)
-	BeforeValidatorSlashed(ctx sdk.Context, valAddr sdk.ValAddress, fraction sdk.Dec)
-	BeforeSlashingUnbondingDelegation(ctx sdk.Context, unbondingDelegation UnbondingDelegation,
-		infractionHeight int64, slashFactor sdk.Dec)
-	BeforeSlashingRedelegation(ctx sdk.Context, srcValidator Validator, redelegation Redelegation,
-		infractionHeight int64, slashFactor sdk.Dec)
+	BeforeValidatorSlashed(ctx sdk.Context, valAddr sdk.ValAddress, infractionHeight int64, slashFactor sdk.Dec)
 }

--- a/x/staking/types/expected_keepers.go
+++ b/x/staking/types/expected_keepers.go
@@ -100,5 +100,5 @@ type StakingHooks interface {
 	BeforeDelegationSharesModified(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) // Must be called when a delegation's shares are modified
 	BeforeDelegationRemoved(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress)        // Must be called when a delegation is removed
 	AfterDelegationModified(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress)
-	BeforeValidatorSlashed(ctx sdk.Context, valAddr sdk.ValAddress, infractionHeight int64, slashFactor sdk.Dec)
+	BeforeValidatorSlashed(ctx sdk.Context, valAddr sdk.ValAddress, infractionHeight int64, slashFactor sdk.Dec, effectiveSlashFactor sdk.Dec)
 }

--- a/x/staking/types/hooks.go
+++ b/x/staking/types/hooks.go
@@ -56,22 +56,8 @@ func (h MultiStakingHooks) AfterDelegationModified(ctx sdk.Context, delAddr sdk.
 		h[i].AfterDelegationModified(ctx, delAddr, valAddr)
 	}
 }
-func (h MultiStakingHooks) BeforeValidatorSlashed(ctx sdk.Context, valAddr sdk.ValAddress, fraction sdk.Dec) {
+func (h MultiStakingHooks) BeforeValidatorSlashed(ctx sdk.Context, valAddr sdk.ValAddress, infractionHeight int64, slashFactor sdk.Dec) {
 	for i := range h {
-		h[i].BeforeValidatorSlashed(ctx, valAddr, fraction)
-	}
-}
-
-func (h MultiStakingHooks) BeforeSlashingUnbondingDelegation(ctx sdk.Context, unbondingDelegation UnbondingDelegation,
-	infractionHeight int64, slashFactor sdk.Dec) {
-	for i := range h {
-		h[i].BeforeSlashingUnbondingDelegation(ctx, unbondingDelegation, infractionHeight, slashFactor)
-	}
-}
-
-func (h MultiStakingHooks) BeforeSlashingRedelegation(ctx sdk.Context, srcValidator Validator, redelegation Redelegation,
-	infractionHeight int64, slashFactor sdk.Dec) {
-	for i := range h {
-		h[i].BeforeSlashingRedelegation(ctx, srcValidator, redelegation, infractionHeight, slashFactor)
+		h[i].BeforeValidatorSlashed(ctx, valAddr, infractionHeight, slashFactor)
 	}
 }

--- a/x/staking/types/hooks.go
+++ b/x/staking/types/hooks.go
@@ -56,8 +56,8 @@ func (h MultiStakingHooks) AfterDelegationModified(ctx sdk.Context, delAddr sdk.
 		h[i].AfterDelegationModified(ctx, delAddr, valAddr)
 	}
 }
-func (h MultiStakingHooks) BeforeValidatorSlashed(ctx sdk.Context, valAddr sdk.ValAddress, infractionHeight int64, slashFactor sdk.Dec) {
+func (h MultiStakingHooks) BeforeValidatorSlashed(ctx sdk.Context, valAddr sdk.ValAddress, infractionHeight int64, slashFactor sdk.Dec, effectiveSlashFactor sdk.Dec) {
 	for i := range h {
-		h[i].BeforeValidatorSlashed(ctx, valAddr, infractionHeight, slashFactor)
+		h[i].BeforeValidatorSlashed(ctx, valAddr, infractionHeight, slashFactor, effectiveSlashFactor)
 	}
 }


### PR DESCRIPTION
Updates slashing hooks as the superlfuid design has changed. The adding of `slashFraction` and `effectiveSlashFraction` is a bit silly. We should get the distribution module to compute effectiveSlashFraction itself later, but leaving that as a TODO for now.


---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)