### PR TITLE
extra logs during commit

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -306,7 +306,6 @@ func (app *BaseApp) Commit() (res abci.ResponseCommit) {
 	// MultiStore (app.cms) so when Commit() is called is persists those values.
 	app.deliverState.ms.Write()
 	commitID := app.cms.Commit()
-	app.logger.Info("commit synced", "commit", fmt.Sprintf("%X", commitID))
 
 	// Reset the Check state to the latest committed.
 	//
@@ -339,6 +338,7 @@ func (app *BaseApp) Commit() (res abci.ResponseCommit) {
 		go app.snapshot(header.Height)
 	}
 
+	app.logger.Info("commited - baseapp", "height", commitID.Version, "commit_hash", commitID.Hash, "retain_height", retainHeight)
 	return abci.ResponseCommit{
 		Data:         commitID.Hash,
 		RetainHeight: retainHeight,

--- a/store/rootmulti/proof_test.go
+++ b/store/rootmulti/proof_test.go
@@ -58,7 +58,7 @@ func TestVerifyIAVLStoreQueryProof(t *testing.T) {
 func TestVerifyMultiStoreQueryProof(t *testing.T) {
 	// Create main tree for testing.
 	db := dbm.NewMemDB()
-	store := NewStore(db, nil)
+	store := NewStore(db, log.NewNopLogger())
 	iavlStoreKey := types.NewKVStoreKey("iavlStoreKey")
 
 	store.MountStoreWithDB(iavlStoreKey, types.StoreTypeIAVL, nil)

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -386,7 +386,7 @@ func (rs *Store) Commit() types.CommitID {
 		version = previousHeight + 1
 	}
 
-	rs.lastCommitInfo = commitStores(version, rs.stores)
+	rs.lastCommitInfo = rs.commitStores(version, rs.stores)
 
 	var pruneErr error
 	defer func ()  {
@@ -412,12 +412,16 @@ func (rs *Store) Commit() types.CommitID {
 
 	// batch prune if the current height is a pruning interval height
 	if rs.pruningOpts.Interval > 0 && version%int64(rs.pruningOpts.Interval) == 0 {
+		rs.logger.Info("prunning", "height", version, "to_prune", rs.pruneHeights)
 		pruneErr = rs.pruneStores()
 	}
 
+	hash, keys := rs.lastCommitInfo.Hash()
+	rs.logger.Info("calculated commit hash", "height", version, "commit_hash", hash, "keys", keys)
+
 	return types.CommitID{
 		Version: version,
-		Hash:    rs.lastCommitInfo.Hash(),
+		Hash:    hash,
 	}
 }
 
@@ -950,6 +954,30 @@ func (rs *Store) buildCommitInfo(version int64) *types.CommitInfo {
 	}
 }
 
+// Commits each store and returns a new commitInfo.
+func (rs *Store) commitStores(version int64, storeMap map[types.StoreKey]types.CommitKVStore) *types.CommitInfo {
+	storeInfos := make([]types.StoreInfo, 0, len(storeMap))
+
+	for key, store := range storeMap {
+		commitID := store.Commit()
+		rs.logger.Info("commit kvstore", "height", commitID.Version, "key", key, "commit_store_hash", commitID.Hash)
+
+		if store.GetStoreType() == types.StoreTypeTransient {
+			continue
+		}
+
+		si := types.StoreInfo{}
+		si.Name = key.Name()
+		si.CommitId = commitID
+		storeInfos = append(storeInfos, si)
+	}
+
+	return &types.CommitInfo{
+		Version:    version,
+		StoreInfos: storeInfos,
+	}
+}
+
 type storeParams struct {
 	key            types.StoreKey
 	db             dbm.DB
@@ -972,29 +1000,6 @@ func getLatestVersion(db dbm.DB) int64 {
 	}
 
 	return latestVersion
-}
-
-// Commits each store and returns a new commitInfo.
-func commitStores(version int64, storeMap map[types.StoreKey]types.CommitKVStore) *types.CommitInfo {
-	storeInfos := make([]types.StoreInfo, 0, len(storeMap))
-
-	for key, store := range storeMap {
-		commitID := store.Commit()
-
-		if store.GetStoreType() == types.StoreTypeTransient {
-			continue
-		}
-
-		si := types.StoreInfo{}
-		si.Name = key.Name()
-		si.CommitId = commitID
-		storeInfos = append(storeInfos, si)
-	}
-
-	return &types.CommitInfo{
-		Version:    version,
-		StoreInfos: storeInfos,
-	}
 }
 
 // Gets commitInfo from disk.

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -412,7 +412,7 @@ func (rs *Store) Commit() types.CommitID {
 
 	// batch prune if the current height is a pruning interval height
 	if rs.pruningOpts.Interval > 0 && version%int64(rs.pruningOpts.Interval) == 0 {
-		rs.logger.Info("prunning", "height", version, "to_prune", rs.pruneHeights)
+		rs.logger.Info("pruning", "height", version, "to_prune", rs.pruneHeights)
 		pruneErr = rs.pruneStores()
 	}
 

--- a/store/types/commit_info.go
+++ b/store/types/commit_info.go
@@ -31,14 +31,14 @@ func (ci CommitInfo) toMap() map[string][]byte {
 }
 
 // Hash returns the simple merkle root hash of the stores sorted by name.
-func (ci CommitInfo) Hash() []byte {
+func (ci CommitInfo) Hash() ([]byte, []string) {
 	// we need a special case for empty set, as SimpleProofsFromMap requires at least one entry
 	if len(ci.StoreInfos) == 0 {
-		return nil
+		return nil, nil
 	}
 
-	rootHash, _, _ := sdkmaps.ProofsFromMap(ci.toMap())
-	return rootHash
+	rootHash, _, keys := sdkmaps.ProofsFromMap(ci.toMap())
+	return rootHash, keys
 }
 
 func (ci CommitInfo) ProofOp(storeName string) tmcrypto.ProofOp {
@@ -66,8 +66,9 @@ func (ci CommitInfo) ProofOp(storeName string) tmcrypto.ProofOp {
 }
 
 func (ci CommitInfo) CommitID() CommitID {
+	hash, _ := ci.Hash()
 	return CommitID{
 		Version: ci.Version,
-		Hash:    ci.Hash(),
+		Hash:    hash,
 	}
 }


### PR DESCRIPTION
## Description

This is to help with root causing: https://github.com/osmosis-labs/osmosis/issues/1090

Currently, the provided logs are inconclusive. So far I can only tell that the faulty node ends up with an app hash that is different from the rest of the network. These extra logs should, hopefully, help us understand which store exactly has a different hash from the rest of the network. Also, if there is any relationship to pruning.