### PR TITLE
fix: data race related to last commmit info and flush prune heights on every change

### DIFF
--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -449,7 +449,7 @@ func (rs *Store) pruneStores() error {
 
 			if err := store.(*iavl.Store).DeleteVersions(rs.pruneHeights...); err != nil {
 				if errCause := errors.Cause(err); errCause != nil && errCause != iavltree.ErrVersionDoesNotExist {
-					return err
+					panic(err)
 				}
 			}
 		}

--- a/store/rootmulti/store_test.go
+++ b/store/rootmulti/store_test.go
@@ -214,7 +214,7 @@ func TestMultistoreLoadWithUpgrade(t *testing.T) {
 	expectedCommitID := getExpectedCommitID(store, 1)
 	checkStore(t, store, expectedCommitID, commitID)
 
-	ci, err := getCommitInfo(db, 1)
+	ci, err := store.getCommitInfoFromDb(1)
 	require.NoError(t, err)
 	require.Equal(t, int64(1), ci.Version)
 	require.Equal(t, 3, len(ci.StoreInfos))
@@ -298,7 +298,7 @@ func TestMultistoreLoadWithUpgrade(t *testing.T) {
 	require.Equal(t, v4, rl4.Get(k4))
 
 	// check commitInfo in storage
-	ci, err = getCommitInfo(db, 2)
+	ci, err = store.getCommitInfoFromDb(2)
 	require.NoError(t, err)
 	require.Equal(t, int64(2), ci.Version)
 	require.Equal(t, 4, len(ci.StoreInfos), ci.StoreInfos)
@@ -358,7 +358,7 @@ func TestMultiStoreRestart(t *testing.T) {
 
 		multi.Commit()
 
-		cinfo, err := getCommitInfo(multi.db, int64(i))
+		cinfo, err := multi.getCommitInfoFromDb(int64(i))
 		require.NoError(t, err)
 		require.Equal(t, int64(i), cinfo.Version)
 	}
@@ -373,7 +373,7 @@ func TestMultiStoreRestart(t *testing.T) {
 
 	multi.Commit()
 
-	flushedCinfo, err := getCommitInfo(multi.db, 3)
+	flushedCinfo, err := multi.getCommitInfoFromDb(3)
 	require.Nil(t, err)
 	require.NotEqual(t, initCid, flushedCinfo, "CID is different after flush to disk")
 
@@ -383,7 +383,7 @@ func TestMultiStoreRestart(t *testing.T) {
 
 	multi.Commit()
 
-	postFlushCinfo, err := getCommitInfo(multi.db, 4)
+	postFlushCinfo, err := multi.getCommitInfoFromDb(4)
 	require.NoError(t, err)
 	require.Equal(t, int64(4), postFlushCinfo.Version, "Commit changed after in-memory commit")
 


### PR DESCRIPTION
**Context**

- Fixed data race related to last commit height concurrently written in `Commit(...)` and read in `Query(...)` and `LastCommitID()`
- flush prune heights every time these are changed to avoid losing them if one of the commits fails