### PR TITLE
fix: data race related to last commit info; flush pruning heights as soon as changed

### DIFF
--- a/pruning/manager.go
+++ b/pruning/manager.go
@@ -80,7 +80,7 @@ func (m *Manager) HandleHeight(previousHeight int64) int64 {
 		defer m.mx.Unlock()
 		defer func() {
 			if shouldFlush {
-				// Must be unlocked since we are under mutex
+				// Must be the unlocked implementation since we are under mutex
 				m.flushAllPruningHeightsUnlocked()
 			}
 		}()

--- a/pruning/manager.go
+++ b/pruning/manager.go
@@ -126,7 +126,7 @@ func (m *Manager) HandleHeightSnapshot(height int64) {
 	defer m.mx.Unlock()
 	m.logger.Debug("HandleHeightSnapshot", "height", height) // TODO: change log level to Debug
 	m.pruneSnapshotHeights.PushBack(height)
-	m.flushPruningSnapshotHeightsUnlocked()
+	// m.flushPruningSnapshotHeightsUnlocked()
 }
 
 // SetSnapshotInterval sets the interval at which the snapshots are taken.

--- a/pruning/manager.go
+++ b/pruning/manager.go
@@ -242,8 +242,6 @@ func (m *Manager) flushPruningSnapshotHeights(batch dbm.Batch) {
 }
 
 func (m *Manager) flushPruningSnapshotHeightsUnlocked(batch dbm.Batch) {
-	m.mx.Lock()
-	defer m.mx.Unlock()
 	bz := make([]byte, 0)
 	for e := m.pruneSnapshotHeights.Front(); e != nil; e = e.Next() {
 		buf := make([]byte, 8)

--- a/pruning/manager_test.go
+++ b/pruning/manager_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func Test_NewManager(t *testing.T) {
-	manager := pruning.NewManager(log.NewNopLogger())
+	manager := pruning.NewManager(log.NewNopLogger(), db.NewMemDB())
 
 	require.NotNil(t, manager)
 	require.NotNil(t, manager.GetPruningHeights())
@@ -75,7 +75,7 @@ func Test_Strategies(t *testing.T) {
 		},
 	}
 
-	manager := pruning.NewManager(log.NewNopLogger())
+	manager := pruning.NewManager(log.NewNopLogger(), db.NewMemDB())
 
 	require.NotNil(t, manager)
 
@@ -143,7 +143,7 @@ func Test_Strategies(t *testing.T) {
 }
 
 func Test_FlushLoad(t *testing.T) {
-	manager := pruning.NewManager(log.NewNopLogger())
+	manager := pruning.NewManager(log.NewNopLogger(), db.NewMemDB())
 	require.NotNil(t, manager)
 
 	db := db.NewMemDB()
@@ -182,7 +182,7 @@ func Test_FlushLoad(t *testing.T) {
 		if curHeight%3 == 0 {
 			require.Equal(t, heightsToPruneMirror, manager.GetPruningHeights(), curHeightStr)
 			batch := db.NewBatch()
-			manager.FlushPruningHeights(batch)
+			manager.FlushPruningHeights()
 			require.NoError(t, batch.Write())
 			require.NoError(t, batch.Close())
 
@@ -197,7 +197,7 @@ func Test_FlushLoad(t *testing.T) {
 }
 
 func Test_WithSnapshot(t *testing.T) {
-	manager := pruning.NewManager(log.NewNopLogger())
+	manager := pruning.NewManager(log.NewNopLogger(), db.NewMemDB())
 	require.NotNil(t, manager)
 
 	curStrategy := types.NewCustomPruningOptions(10, 10)

--- a/pruning/manager_test.go
+++ b/pruning/manager_test.go
@@ -182,7 +182,7 @@ func Test_FlushLoad(t *testing.T) {
 		if curHeight%3 == 0 {
 			require.Equal(t, heightsToPruneMirror, manager.GetPruningHeights(), curHeightStr)
 			batch := db.NewBatch()
-			manager.FlushPruningHeights()
+			manager.FlushAllPruningHeights()
 			require.NoError(t, batch.Write())
 			require.NoError(t, batch.Close())
 

--- a/pruning/manager_test.go
+++ b/pruning/manager_test.go
@@ -234,9 +234,6 @@ func Test_FlushLoad_PruneSnapshotHeights(t *testing.T) {
 			wg.Add(1)
 			// Mimic taking snapshot in a separate goroutine
 			go func(h int64) {
-
-				// Mimic delay to take snapshots
-				time.Sleep(30 * time.Millisecond)
 				manager.HandleHeightSnapshot(h)
 				wg.Done()
 			}(curHeight)
@@ -254,7 +251,7 @@ func Test_FlushLoad_PruneSnapshotHeights(t *testing.T) {
 	require.Equal(t, int64(lastHeight-pruningKeepRecent), handleHeightActual)
 
 	pruningHeights := manager.GetPruningHeights()
-	require.Equal(t, int(totalHeights+1-1-pruningKeepRecent), len(pruningHeights))
+	require.Equal(t, int(lastHeight-1-pruningKeepRecent), len(pruningHeights))
 }
 
 func Test_WithSnapshot(t *testing.T) {

--- a/pruning/manager_test.go
+++ b/pruning/manager_test.go
@@ -144,16 +144,18 @@ func Test_Strategies(t *testing.T) {
 
 // Here, we focus on testing the correctness of flushing pruneHeights to disk and loading back.
 func Test_FlushLoad_PruneHeights(t *testing.T) {
-	db := db.NewMemDB()
-
-	manager := pruning.NewManager(log.NewNopLogger(), db)
+	const (
+		pruningKeepRecent = 100
+		totalHeights      = int64(1000)
+		snapshotInterval = uint64(10)
+	)
+	var(
+		curStrategy = types.NewCustomPruningOptions(uint64(pruningKeepRecent), 15)
+		db = db.NewMemDB()
+		manager = pruning.NewManager(log.NewNopLogger(), db)
+	)
 	require.NotNil(t, manager)
-
-	const pruningKeepRecent = 100
-
-	curStrategy := types.NewCustomPruningOptions(uint64(pruningKeepRecent), 15)
-
-	snapshotInterval := uint64(10)
+	
 	manager.SetSnapshotInterval(snapshotInterval)
 
 	manager.SetOptions(curStrategy)
@@ -161,7 +163,7 @@ func Test_FlushLoad_PruneHeights(t *testing.T) {
 
 	heightsToPruneMirror := make([]int64, 0)
 
-	for curHeight := int64(1); curHeight < 1000; curHeight++ {
+	for curHeight := int64(1); curHeight < totalHeights; curHeight++ {
 		handleHeightActual := manager.HandleHeight(curHeight)
 
 		curHeightStr := fmt.Sprintf("height: %d", curHeight)

--- a/pruning/manager_test.go
+++ b/pruning/manager_test.go
@@ -26,50 +26,50 @@ func Test_NewManager(t *testing.T) {
 
 func Test_Strategies(t *testing.T) {
 	testcases := map[string]struct {
-		strategy *types.PruningOptions
+		strategy         *types.PruningOptions
 		snapshotInterval uint64
 		strategyToAssert types.PruningStrategy
-		isValid  bool
+		isValid          bool
 	}{
 		"prune nothing - no snapshot": {
-			strategy: types.NewPruningOptions(types.PruningNothing),
+			strategy:         types.NewPruningOptions(types.PruningNothing),
 			strategyToAssert: types.PruningNothing,
 		},
 		"prune nothing - snapshot": {
-			strategy: types.NewPruningOptions(types.PruningNothing),
+			strategy:         types.NewPruningOptions(types.PruningNothing),
 			strategyToAssert: types.PruningNothing,
 			snapshotInterval: 100,
 		},
 		"prune default - no snapshot": {
-			strategy: types.NewPruningOptions(types.PruningDefault),
+			strategy:         types.NewPruningOptions(types.PruningDefault),
 			strategyToAssert: types.PruningDefault,
 		},
 		"prune default - snapshot": {
-			strategy: types.NewPruningOptions(types.PruningDefault),
+			strategy:         types.NewPruningOptions(types.PruningDefault),
 			strategyToAssert: types.PruningDefault,
 			snapshotInterval: 100,
 		},
 		"prune everything - no snapshot": {
-			strategy: types.NewPruningOptions(types.PruningEverything),
+			strategy:         types.NewPruningOptions(types.PruningEverything),
 			strategyToAssert: types.PruningEverything,
 		},
 		"prune everything - snapshot": {
-			strategy: types.NewPruningOptions(types.PruningEverything),
+			strategy:         types.NewPruningOptions(types.PruningEverything),
 			strategyToAssert: types.PruningEverything,
 			snapshotInterval: 100,
 		},
 		"custom 100-10-15": {
-			strategy: types.NewCustomPruningOptions(100, 15),
+			strategy:         types.NewCustomPruningOptions(100, 15),
 			snapshotInterval: 10,
 			strategyToAssert: types.PruningCustom,
 		},
 		"custom 10-10-15": {
-			strategy: types.NewCustomPruningOptions(10, 15),
+			strategy:         types.NewCustomPruningOptions(10, 15),
 			snapshotInterval: 10,
 			strategyToAssert: types.PruningCustom,
 		},
 		"custom 100-0-15": {
-			strategy: types.NewCustomPruningOptions(100, 15),
+			strategy:         types.NewCustomPruningOptions(100, 15),
 			snapshotInterval: 0,
 			strategyToAssert: types.PruningCustom,
 		},
@@ -81,9 +81,9 @@ func Test_Strategies(t *testing.T) {
 
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
-			curStrategy := tc.strategy 
+			curStrategy := tc.strategy
 			manager.SetSnapshotInterval(tc.snapshotInterval)
-			
+
 			pruneStrategy := curStrategy.GetPruningStrategy()
 			require.Equal(t, tc.strategyToAssert, pruneStrategy)
 
@@ -142,13 +142,16 @@ func Test_Strategies(t *testing.T) {
 	}
 }
 
-func Test_FlushLoad(t *testing.T) {
-	manager := pruning.NewManager(log.NewNopLogger(), db.NewMemDB())
-	require.NotNil(t, manager)
-
+// Here, we focus on testing the correctness of flushing pruneHeights to disk and loading back.
+func Test_FlushLoad_PruneHeights(t *testing.T) {
 	db := db.NewMemDB()
 
-	curStrategy := types.NewCustomPruningOptions(100, 15)
+	manager := pruning.NewManager(log.NewNopLogger(), db)
+	require.NotNil(t, manager)
+
+	const pruningKeepRecent = 100
+
+	curStrategy := types.NewCustomPruningOptions(uint64(pruningKeepRecent), 15)
 
 	snapshotInterval := uint64(10)
 	manager.SetSnapshotInterval(snapshotInterval)
@@ -156,44 +159,100 @@ func Test_FlushLoad(t *testing.T) {
 	manager.SetOptions(curStrategy)
 	require.Equal(t, curStrategy, manager.GetOptions())
 
-	keepRecent := curStrategy.KeepRecent
-
 	heightsToPruneMirror := make([]int64, 0)
 
-	for curHeight := int64(0); curHeight < 1000; curHeight++ {
+	for curHeight := int64(1); curHeight < 1000; curHeight++ {
 		handleHeightActual := manager.HandleHeight(curHeight)
 
 		curHeightStr := fmt.Sprintf("height: %d", curHeight)
 
-		if curHeight > int64(keepRecent) && (snapshotInterval != 0 && (curHeight-int64(keepRecent))%int64(snapshotInterval) != 0 || snapshotInterval == 0) {
-			expectedHandleHeight := curHeight - int64(keepRecent)
-			require.Equal(t, expectedHandleHeight, handleHeightActual, curHeightStr)
-			heightsToPruneMirror = append(heightsToPruneMirror, expectedHandleHeight)
-		} else {
-			require.Equal(t, int64(0), handleHeightActual, curHeightStr)
-		}
+		// flush should happen every time a height is persisted
+		if handleHeightActual > 0 {
+			heightsToPruneMirror = append(heightsToPruneMirror, curHeight-pruningKeepRecent)
 
-		if manager.ShouldPruneAtHeight(curHeight) {
-			manager.ResetPruningHeights()
-			heightsToPruneMirror = make([]int64, 0)
-		}
-
-		// N.B.: There is no reason behind the choice of 3.
-		if curHeight%3 == 0 {
-			require.Equal(t, heightsToPruneMirror, manager.GetPruningHeights(), curHeightStr)
-			batch := db.NewBatch()
-			manager.FlushAllPruningHeights()
-			require.NoError(t, batch.Write())
-			require.NoError(t, batch.Close())
+			actualPruningHeightsBeforeLoad := manager.GetPruningHeights()
+			require.Equal(t, heightsToPruneMirror, actualPruningHeightsBeforeLoad)
 
 			manager.ResetPruningHeights()
-			require.Equal(t, make([]int64, 0), manager.GetPruningHeights(), curHeightStr)
 
 			err := manager.LoadPruningHeights(db)
 			require.NoError(t, err)
-			require.Equal(t, heightsToPruneMirror, manager.GetPruningHeights(), curHeightStr)
+
+			actualPruningHeightsAfterLoad := manager.GetPruningHeights()
+			require.Equal(t, actualPruningHeightsBeforeLoad, actualPruningHeightsAfterLoad, curHeightStr)
 		}
 	}
+}
+
+// In this test, we focus on the correctness of flushing pruneSnapshotHeight to disk and loading back.
+// To do so, we assert that, eventually, all heights are moved from pruningSnapshotHeights
+// to pruningHeighs. Additionally, we claim all heights are preserved even in the conditions
+// when they are periodically flushed to disk, reset and then loaded back from disk into memory.
+func Test_FlushLoad_PruneSnapshotHeights(t *testing.T) {
+	const (
+		pruningKeepRecent = 30
+		totalHeights      = int64(1000)
+		snapshotInterval  = uint64(10)
+	)
+
+	var (
+		db          = db.NewMemDB()
+		manager     = pruning.NewManager(log.NewNopLogger(), db)
+		curStrategy = types.NewCustomPruningOptions(uint64(pruningKeepRecent), 15)
+		wg          = &sync.WaitGroup{}
+	)
+	require.NotNil(t, manager)
+
+	manager.SetSnapshotInterval(snapshotInterval)
+	manager.SetOptions(curStrategy)
+	require.Equal(t, curStrategy, manager.GetOptions())
+
+	for curHeight := int64(1); curHeight < totalHeights; curHeight++ {
+		// We always use previous height for handling pruning
+		// but current height for snapshots
+		previousHeight := curHeight - 1
+
+		handleHeightActual := manager.HandleHeight(previousHeight)
+
+		// No flush / update should happen at snapshot heights
+		if previousHeight%int64(snapshotInterval) == 0 {
+			require.True(t, handleHeightActual == 0)
+		}
+
+		// flush should happen every time a height is persisted
+		if handleHeightActual > 0 {
+
+			manager.ResetPruningHeights()
+
+			err := manager.LoadPruningHeights(db)
+			require.NoError(t, err)
+		}
+
+		if curHeight%int64(snapshotInterval) == 0 {
+			wg.Add(1)
+			// Mimic taking snapshot in a separate goroutine
+			go func(h int64) {
+
+				// Mimic delay to take snapshots
+				time.Sleep(30 * time.Millisecond)
+				manager.HandleHeightSnapshot(h)
+				wg.Done()
+			}(curHeight)
+		}
+	}
+
+	wg.Wait()
+
+	// We call HandleHeight(lastHeight) after wg.Wait() because the pruningSnapshotHeights are moved to pruningHeights
+	// only when HandleHeight(...) is called.
+	// Doing the call to HandleHeight(...) after all snapshots are complete (this is ensured by the wait group above),
+	// allows us to assert with confidence on what pruneHeights should contain.
+	lastHeight := totalHeights + 1
+	handleHeightActual := manager.HandleHeight(lastHeight)
+	require.Equal(t, int64(lastHeight-pruningKeepRecent), handleHeightActual)
+
+	pruningHeights := manager.GetPruningHeights()
+	require.Equal(t, int(totalHeights+1-1-pruningKeepRecent), len(pruningHeights))
 }
 
 func Test_WithSnapshot(t *testing.T) {
@@ -201,7 +260,7 @@ func Test_WithSnapshot(t *testing.T) {
 	require.NotNil(t, manager)
 
 	curStrategy := types.NewCustomPruningOptions(10, 10)
-	
+
 	snapshotInterval := uint64(15)
 	manager.SetSnapshotInterval(snapshotInterval)
 

--- a/pruning/metadata/flush.go
+++ b/pruning/metadata/flush.go
@@ -1,0 +1,53 @@
+package metadata
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+
+	dbm "github.com/tendermint/tm-db"
+)
+
+const(
+	uint64Size = 8
+
+	pruneHeightsKey         = "s/pruneheights"
+)
+
+type Flusher interface {
+	Flush()
+
+	FlushBatch(data interface{}, batch dbm.Batch)
+
+	Load()
+}
+
+type PruneHeightFlusher struct {
+
+}
+
+func (*PruneHeightFlusher) FlushBatch(data interface{}, batch dbm.Batch) {
+	pruneHeights, ok := data.([]int64)
+
+	if !ok {
+		panic(errors.New(""))
+	}
+
+	switch t := data.(type) { 
+    default:
+        panic(fmt.Sprintf("unexpected type %T", t))
+    case []int64:
+        
+    }
+
+	bz := make([]byte, 0, uint64Size * len(pruneHeights))
+		for _, ph := range pruneHeights {
+			buf := make([]byte, uint64Size)
+			binary.BigEndian.PutUint64(buf, uint64(ph))
+			bz = append(bz, buf...)
+		}
+	
+		if err := batch.Set([]byte(pruneHeightsKey), bz); err != nil {
+			panic(err)
+		}
+}

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -425,7 +425,7 @@ func (rs *Store) Commit() types.CommitID {
 	rs.mx.RLock()
 	hash, keys := rs.lastCommitInfo.Hash()
 	defer rs.mx.RUnlock()
-	rs.logger.Info("calculated commit hash", "height", version, "commit_hash", hash, "keys", keys)
+	rs.logger.Info("calculated commit hash", "height", version, "commit_hash", fmt.Sprintf("%X", hash), "keys", keys)
 
 	return types.CommitID{
 		Version: version,

--- a/store/rootmulti/store_test.go
+++ b/store/rootmulti/store_test.go
@@ -215,7 +215,7 @@ func TestMultistoreLoadWithUpgrade(t *testing.T) {
 	expectedCommitID := getExpectedCommitID(store, 1)
 	checkStore(t, store, expectedCommitID, commitID)
 
-	ci, err := getCommitInfo(db, 1)
+	ci, err := store.getCommitInfoFromDb(1)
 	require.NoError(t, err)
 	require.Equal(t, int64(1), ci.Version)
 	require.Equal(t, 3, len(ci.StoreInfos))
@@ -299,7 +299,7 @@ func TestMultistoreLoadWithUpgrade(t *testing.T) {
 	require.Equal(t, v4, rl4.Get(k4))
 
 	// check commitInfo in storage
-	ci, err = getCommitInfo(db, 2)
+	ci, err = store.getCommitInfoFromDb(2)
 	require.NoError(t, err)
 	require.Equal(t, int64(2), ci.Version)
 	require.Equal(t, 4, len(ci.StoreInfos), ci.StoreInfos)
@@ -355,7 +355,7 @@ func TestMultiStoreRestart(t *testing.T) {
 
 		multi.Commit()
 
-		cinfo, err := getCommitInfo(multi.db, int64(i))
+		cinfo, err := multi.getCommitInfoFromDb(int64(i))
 		require.NoError(t, err)
 		require.Equal(t, int64(i), cinfo.Version)
 	}
@@ -370,7 +370,7 @@ func TestMultiStoreRestart(t *testing.T) {
 
 	multi.Commit()
 
-	flushedCinfo, err := getCommitInfo(multi.db, 3)
+	flushedCinfo, err := multi.getCommitInfoFromDb(3)
 	require.Nil(t, err)
 	require.NotEqual(t, initCid, flushedCinfo, "CID is different after flush to disk")
 
@@ -380,7 +380,7 @@ func TestMultiStoreRestart(t *testing.T) {
 
 	multi.Commit()
 
-	postFlushCinfo, err := getCommitInfo(multi.db, 4)
+	postFlushCinfo, err := multi.getCommitInfoFromDb(4)
 	require.NoError(t, err)
 	require.Equal(t, int64(4), postFlushCinfo.Version, "Commit changed after in-memory commit")
 


### PR DESCRIPTION
**Context**

- Fixed data race related to last commit height concurrently written in `Commit(...)` and read in `Query(...)` and `LastCommitID()`
- flush prune heights every time these are changed to avoid losing them if one of the commits fails
   * Related to: https://github.com/osmosis-labs/cosmos-sdk/issues/149
- flush commit id and version atomically with updating `rs.lastCommitInfo`

Left some extra comments in code

**Risks**
- This change introduced performance overhead due to synchronization in exchange for safety