### PR TITLE
fix: commit info data race

### DIFF
--- a/pruning/manager.go
+++ b/pruning/manager.go
@@ -218,7 +218,7 @@ func (m *Manager) flushPruningHeights(batch dbm.Batch) {
 func (m *Manager) flushPruningSnapshotHeights(batch dbm.Batch) {
 	m.mx.Lock()
 	defer m.mx.Unlock()
-	bz := make([]byte, 0, m.pruneSnapshotHeights.Len())
+	bz := make([]byte, 0, m.pruneSnapshotHeights.Len() * uint64Size)
 	for e := m.pruneSnapshotHeights.Front(); e != nil; e = e.Next() {
 		buf := make([]byte, uint64Size)
 		binary.BigEndian.PutUint64(buf, uint64(e.Value.(int64)))

--- a/pruning/manager.go
+++ b/pruning/manager.go
@@ -204,7 +204,9 @@ func (m *Manager) flushPruningHeights(batch dbm.Batch) {
 		bz = append(bz, buf...)
 	}
 
-	batch.Set([]byte(pruneHeightsKey), bz)
+	if err := batch.Set([]byte(pruneHeightsKey), bz); err != nil {
+		panic(err)
+	}
 }
 
 func (m *Manager) flushPruningSnapshotHeights(batch dbm.Batch) {
@@ -216,5 +218,7 @@ func (m *Manager) flushPruningSnapshotHeights(batch dbm.Batch) {
 		binary.BigEndian.PutUint64(buf, uint64(e.Value.(int64)))
 		bz = append(bz, buf...)
 	}
-	batch.Set([]byte(pruneSnapshotHeightsKey), bz)
+	if err := batch.Set([]byte(pruneSnapshotHeightsKey), bz); err != nil {
+		panic(err)
+	}
 }

--- a/pruning/manager_test.go
+++ b/pruning/manager_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func Test_NewManager(t *testing.T) {
-	manager := pruning.NewManager(log.NewNopLogger())
+	manager := pruning.NewManager(log.NewNopLogger(), db.NewMemDB())
 
 	require.NotNil(t, manager)
 	require.NotNil(t, manager.GetPruningHeights())
@@ -75,7 +75,7 @@ func Test_Strategies(t *testing.T) {
 		},
 	}
 
-	manager := pruning.NewManager(log.NewNopLogger())
+	manager := pruning.NewManager(log.NewNopLogger(), db.NewMemDB())
 
 	require.NotNil(t, manager)
 
@@ -143,7 +143,7 @@ func Test_Strategies(t *testing.T) {
 }
 
 func Test_FlushLoad(t *testing.T) {
-	manager := pruning.NewManager(log.NewNopLogger())
+	manager := pruning.NewManager(log.NewNopLogger(), db.NewMemDB())
 	require.NotNil(t, manager)
 
 	db := db.NewMemDB()
@@ -182,7 +182,7 @@ func Test_FlushLoad(t *testing.T) {
 		if curHeight%3 == 0 {
 			require.Equal(t, heightsToPruneMirror, manager.GetPruningHeights(), curHeightStr)
 			batch := db.NewBatch()
-			manager.FlushPruningHeights(batch)
+			manager.FlushPruningHeights()
 			require.NoError(t, batch.Write())
 			require.NoError(t, batch.Close())
 
@@ -197,7 +197,7 @@ func Test_FlushLoad(t *testing.T) {
 }
 
 func Test_WithSnapshot(t *testing.T) {
-	manager := pruning.NewManager(log.NewNopLogger())
+	manager := pruning.NewManager(log.NewNopLogger(), db.NewMemDB())
 	require.NotNil(t, manager)
 
 	curStrategy := types.NewCustomPruningOptions(10, 10)

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -530,6 +530,8 @@ func (rs *Store) GetKVStore(key types.StoreKey) types.KVStore {
 }
 
 func (rs *Store) handlePruning(version int64) error {
+	defer rs.pruningManager.FlushPruningHeights()
+
 	rs.pruningManager.HandleHeight(version - 1) // we should never prune the current version.
 	if rs.pruningManager.ShouldPruneAtHeight(version) {
 		rs.logger.Info("prune start", "height", version)
@@ -549,7 +551,7 @@ func (rs *Store) handlePruning(version int64) error {
 
 				if err := store.(*iavl.Store).DeleteVersions(pruningHeights...); err != nil {
 					if errCause := errors.Cause(err); errCause != nil && errCause != iavltree.ErrVersionDoesNotExist {
-						panic(err)
+						return err
 					}
 				}
 			}

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -428,7 +428,7 @@ func (rs *Store) Commit() types.CommitID {
 	rs.mx.RLock()
 	hash, keys := rs.lastCommitInfo.Hash()
 	defer rs.mx.RUnlock()
-	rs.logger.Info("calculated commit hash", "height", version, "commit_hash", hash, "keys", keys)
+	rs.logger.Info("calculated commit hash", "height", version, "commit_hash", fmt.Sprintf("%X", hash), "keys", keys)
 
 	return types.CommitID{
 		Version: version,

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -1011,7 +1011,7 @@ func (rs *Store) flushLastCommitInfo(cInfo *types.CommitInfo) {
 	setCommitInfo(batch, cInfo)
 	setLatestVersion(batch, cInfo.Version)
 
-	if err := batch.Write(); err != nil {
+	if err := batch.WriteSync(); err != nil {
 		panic(fmt.Errorf("error on batch write %w", err))
 	}
 }

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/cosmos/cosmos-sdk/pruning"
 	pruningTypes "github.com/cosmos/cosmos-sdk/pruning/types"
@@ -45,6 +46,13 @@ const (
 	snapshotMaxItemSize = int(64e6) // SDK has no key/value size limit, so we set an arbitrary limit
 )
 
+type storeParams struct {
+	key            types.StoreKey
+	db             dbm.DB
+	typ            types.StoreType
+	initialVersion uint64
+}
+
 // Store is composed of many CommitStores. Name contrasts with
 // cacheMultiStore which is used for branching other MultiStores. It implements
 // the CommitMultiStore interface.
@@ -52,6 +60,7 @@ type Store struct {
 	db             dbm.DB
 	logger         log.Logger
 	lastCommitInfo *types.CommitInfo
+	mx *sync.RWMutex // mutex to sync access to lastCommitInfo
 	pruningManager *pruning.Manager
 	iavlCacheSize  int
 	storesParams   map[types.StoreKey]storeParams
@@ -86,7 +95,8 @@ func NewStore(db dbm.DB, logger log.Logger) *Store {
 		stores:         make(map[types.StoreKey]types.CommitKVStore),
 		keysByName:     make(map[string]types.StoreKey),
 		listeners:      make(map[types.StoreKey][]types.WriteListener),
-		pruningManager: pruning.NewManager(logger),
+		pruningManager: pruning.NewManager(logger, db),
+		mx: &sync.RWMutex{},
 	}
 }
 
@@ -197,7 +207,7 @@ func (rs *Store) loadVersion(ver int64, upgrades *types.StoreUpgrades) error {
 	// load old data if we are not version 0
 	if ver != 0 {
 		var err error
-		cInfo, err = getCommitInfo(rs.db, ver)
+		cInfo, err = rs.getCommitInfoFromDb(ver)
 		if err != nil {
 			return err
 		}
@@ -378,6 +388,8 @@ func (rs *Store) ListeningEnabled(key types.StoreKey) bool {
 
 // LastCommitID implements Committer/CommitStore.
 func (rs *Store) LastCommitID() types.CommitID {
+	rs.mx.RLock()
+	defer rs.mx.RUnlock()
 	if rs.lastCommitInfo == nil {
 		return types.CommitID{
 			Version: getLatestVersion(rs.db),
@@ -405,19 +417,17 @@ func (rs *Store) Commit() types.CommitID {
 		version = previousHeight + 1
 	}
 
-	rs.lastCommitInfo = rs.commitStores(version, rs.stores)
+	newCommitInfo := rs.commitStores(version, rs.stores)
+	rs.updateLatestCommitInfo(newCommitInfo, version)
 
-	var pruneErr error
-	defer func() {
-		rs.flushMetadata(rs.db, version, rs.lastCommitInfo)
-		if pruneErr != nil {
-			panic(pruneErr)
-		}
-	}()
+	err := rs.handlePruning(version)
+	if err != nil {
+		panic(err)
+	}
 
-	pruneErr = rs.handlePruning(version)
-
+	rs.mx.RLock()
 	hash, keys := rs.lastCommitInfo.Hash()
+	defer rs.mx.RUnlock()
 	rs.logger.Info("calculated commit hash", "height", version, "commit_hash", hash, "keys", keys)
 
 	return types.CommitID{
@@ -539,7 +549,7 @@ func (rs *Store) handlePruning(version int64) error {
 
 				if err := store.(*iavl.Store).DeleteVersions(pruningHeights...); err != nil {
 					if errCause := errors.Cause(err); errCause != nil && errCause != iavltree.ErrVersionDoesNotExist {
-						return err
+						panic(err)
 					}
 				}
 			}
@@ -603,18 +613,10 @@ func (rs *Store) Query(req abci.RequestQuery) abci.ResponseQuery {
 		return sdkerrors.QueryResult(sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "proof is unexpectedly empty; ensure height has not been pruned"))
 	}
 
-	// If the request's height is the latest height we've committed, then utilize
-	// the store's lastCommitInfo as this commit info may not be flushed to disk.
-	// Otherwise, we query for the commit info from disk.
-	var commitInfo *types.CommitInfo
 
-	if res.Height == rs.lastCommitInfo.Version {
-		commitInfo = rs.lastCommitInfo
-	} else {
-		commitInfo, err = getCommitInfo(rs.db, res.Height)
-		if err != nil {
-			return sdkerrors.QueryResult(err)
-		}
+	commitInfo, err := rs.getCommitInfoFromDb(res.Height)
+	if err != nil {
+		return sdkerrors.QueryResult(err)
 	}
 
 	// Restore origin path and append proof op.
@@ -887,7 +889,8 @@ func (rs *Store) Restore(
 		importer.Close()
 	}
 
-	rs.flushMetadata(rs.db, int64(height), rs.buildCommitInfo(int64(height)))
+	rs.flushLastCommitInfo(rs.buildCommitInfo(int64(height)))
+	rs.pruningManager.FlushPruningHeights()
 	return rs.LoadLatestVersion()
 }
 
@@ -992,26 +995,42 @@ func (rs *Store) commitStores(version int64, storeMap map[types.StoreKey]types.C
 	}
 }
 
-func (rs *Store) flushMetadata(db dbm.DB, version int64, cInfo *types.CommitInfo) {
-	rs.logger.Debug("flushing metadata", "height", version)
-	batch := db.NewBatch()
+func (rs *Store) updateLatestCommitInfo(newCommitInfo *types.CommitInfo, version int64) {
+	rs.mx.Lock()
+	defer rs.mx.Unlock()
+	rs.lastCommitInfo = newCommitInfo
+	rs.flushLastCommitInfo(newCommitInfo)
+}
+
+func (rs *Store) flushLastCommitInfo(cInfo *types.CommitInfo) {
+	batch := rs.db.NewBatch()
 	defer batch.Close()
 
-	flushCommitInfo(batch, version, cInfo)
-	flushLatestVersion(batch, version)
-	rs.pruningManager.FlushPruningHeights(batch)
+	setCommitInfo(batch, cInfo)
+	setLatestVersion(batch, cInfo.Version)
 
 	if err := batch.Write(); err != nil {
 		panic(fmt.Errorf("error on batch write %w", err))
 	}
-	rs.logger.Debug("flushing metadata finished", "height", version)
 }
 
-type storeParams struct {
-	key            types.StoreKey
-	db             dbm.DB
-	typ            types.StoreType
-	initialVersion uint64
+// Gets commitInfo from disk.
+func (rs *Store) getCommitInfoFromDb(ver int64) (*types.CommitInfo, error) {
+	cInfoKey := fmt.Sprintf(commitInfoKeyFmt, ver)
+
+	bz, err := rs.db.Get([]byte(cInfoKey))
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get commit info")
+	} else if bz == nil {
+		return nil, errors.New("no commit info found")
+	}
+
+	cInfo := &types.CommitInfo{}
+	if err = cInfo.Unmarshal(bz); err != nil {
+		return nil, errors.Wrap(err, "failed unmarshal commit info")
+	}
+
+	return cInfo, nil
 }
 
 func (rs *Store) doProofsQuery(req abci.RequestQuery) abci.ResponseQuery {
@@ -1049,36 +1068,17 @@ func getLatestVersion(db dbm.DB) int64 {
 	return latestVersion
 }
 
-// Gets commitInfo from disk.
-func getCommitInfo(db dbm.DB, ver int64) (*types.CommitInfo, error) {
-	cInfoKey := fmt.Sprintf(commitInfoKeyFmt, ver)
-
-	bz, err := db.Get([]byte(cInfoKey))
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get commit info")
-	} else if bz == nil {
-		return nil, errors.New("no commit info found")
-	}
-
-	cInfo := &types.CommitInfo{}
-	if err = cInfo.Unmarshal(bz); err != nil {
-		return nil, errors.Wrap(err, "failed unmarshal commit info")
-	}
-
-	return cInfo, nil
-}
-
-func flushCommitInfo(batch dbm.Batch, version int64, cInfo *types.CommitInfo) {
+func setCommitInfo(batch dbm.Batch, cInfo *types.CommitInfo) {
 	bz, err := cInfo.Marshal()
 	if err != nil {
 		panic(err)
 	}
 
-	cInfoKey := fmt.Sprintf(commitInfoKeyFmt, version)
+	cInfoKey := fmt.Sprintf(commitInfoKeyFmt, cInfo.Version)
 	batch.Set([]byte(cInfoKey), bz)
 }
 
-func flushLatestVersion(batch dbm.Batch, version int64) {
+func setLatestVersion(batch dbm.Batch, version int64) {
 	bz, err := gogotypes.StdInt64Marshal(version)
 	if err != nil {
 		panic(err)

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -1036,7 +1036,7 @@ func (rs *Store) getCommitInfoFromDb(ver int64) (*types.CommitInfo, error) {
 }
 
 func (rs *Store) doProofsQuery(req abci.RequestQuery) abci.ResponseQuery {
-	commitInfo, err := getCommitInfo(rs.db, req.Height)
+	commitInfo, err := rs.getCommitInfoFromDb(req.Height)
 	if err != nil {
 		return sdkerrors.QueryResult(err)
 	}

--- a/store/rootmulti/store_test.go
+++ b/store/rootmulti/store_test.go
@@ -215,7 +215,7 @@ func TestMultistoreLoadWithUpgrade(t *testing.T) {
 	expectedCommitID := getExpectedCommitID(store, 1)
 	checkStore(t, store, expectedCommitID, commitID)
 
-	ci, err := getCommitInfo(db, 1)
+	ci, err := store.getCommitInfoFromDb(1)
 	require.NoError(t, err)
 	require.Equal(t, int64(1), ci.Version)
 	require.Equal(t, 3, len(ci.StoreInfos))
@@ -299,7 +299,7 @@ func TestMultistoreLoadWithUpgrade(t *testing.T) {
 	require.Equal(t, v4, rl4.Get(k4))
 
 	// check commitInfo in storage
-	ci, err = getCommitInfo(db, 2)
+	ci, err = store.getCommitInfoFromDb(2)
 	require.NoError(t, err)
 	require.Equal(t, int64(2), ci.Version)
 	require.Equal(t, 4, len(ci.StoreInfos), ci.StoreInfos)
@@ -355,7 +355,7 @@ func TestMultiStoreRestart(t *testing.T) {
 
 		multi.Commit()
 
-		cinfo, err := getCommitInfo(multi.db, int64(i))
+		cinfo, err := multi.getCommitInfoFromDb(int64(i))
 		require.NoError(t, err)
 		require.Equal(t, int64(i), cinfo.Version)
 	}
@@ -370,7 +370,7 @@ func TestMultiStoreRestart(t *testing.T) {
 
 	multi.Commit()
 
-	flushedCinfo, err := getCommitInfo(multi.db, 3)
+	flushedCinfo, err := multi.getCommitInfoFromDb(3)
 	require.Nil(t, err)
 	require.NotEqual(t, initCid, flushedCinfo, "CID is different after flush to disk")
 
@@ -380,7 +380,7 @@ func TestMultiStoreRestart(t *testing.T) {
 
 	multi.Commit()
 
-	postFlushCinfo, err := getCommitInfo(multi.db, 4)
+	postFlushCinfo, err := multi.getCommitInfoFromDb(4)
 	require.NoError(t, err)
 	require.Equal(t, int64(4), postFlushCinfo.Version, "Commit changed after in-memory commit")
 


### PR DESCRIPTION
**Context**

- Fixed data race related to last commit height concurrently written in `Commit(...)` and read in `Query(...)` and `LastCommitID()`
- flush commit id and version atomically with updating `rs.lastCommitInfo`
- `WriteSync` when flushing metadata since we want it to be immediately written to disk to avoid losing it

**Risks**
- This change introduced performance overhead due to synchronization in exchange for safety