### PR TITLE
fix: proofs query to help debug app hash

### DIFF
--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -1048,7 +1048,7 @@ func (rs *Store) doProofsQuery(req abci.RequestQuery) abci.ResponseQuery {
 	}
 
 	for _, storeInfo := range commitInfo.StoreInfos {
-		res.ProofOps.Ops = append(res.ProofOps.Ops, commitInfo.ProofOp(storeInfo.Name))
+		res.ProofOps.Ops = append(res.ProofOps.Ops, crypto.ProofOp{Key: []byte(storeInfo.Name), Data: storeInfo.CommitId.Hash, })
 	}
 	return res
 }


### PR DESCRIPTION
This functionality was implemented in #156 

I realized that I need a different hash to help with determining which store was faulty upon getting the app hash error. This PR fixes it.