### PR TITLE
refactor: syncronize pruning manager

### DIFF
--- a/pruning/export_test.go
+++ b/pruning/export_test.go
@@ -9,4 +9,6 @@ var (
 	// functions
 	Int64SliceToBytes = int64SliceToBytes
 	ListToBytes       = listToBytes
+	LoadPruningHeights = loadPruningHeights
+	LoadPruningSnapshotHeights = loadPruningSnapshotHeights
 )

--- a/pruning/export_test.go
+++ b/pruning/export_test.go
@@ -7,8 +7,8 @@ var (
 	PruneSnapshotHeightsKey = pruneSnapshotHeightsKey
 
 	// functions
-	Int64SliceToBytes = int64SliceToBytes
-	ListToBytes       = listToBytes
-	LoadPruningHeights = loadPruningHeights
+	Int64SliceToBytes          = int64SliceToBytes
+	ListToBytes                = listToBytes
+	LoadPruningHeights         = loadPruningHeights
 	LoadPruningSnapshotHeights = loadPruningSnapshotHeights
 )

--- a/pruning/manager.go
+++ b/pruning/manager.go
@@ -13,14 +13,14 @@ import (
 )
 
 type Manager struct {
-	db             dbm.DB
-	logger               log.Logger
-	opts                 types.PruningOptions
-	snapshotInterval     uint64
-	pruneHeights         []int64
-	pruneHeightsMx	   sync.Mutex
-	pruneSnapshotHeights *list.List
-	pruneSnapshotHeightsMx                   sync.Mutex
+	db                     dbm.DB
+	logger                 log.Logger
+	opts                   types.PruningOptions
+	snapshotInterval       uint64
+	pruneHeights           []int64
+	pruneHeightsMx         sync.Mutex
+	pruneSnapshotHeights   *list.List
+	pruneSnapshotHeightsMx sync.Mutex
 }
 
 const errNegativeHeightsFmt = "failed to get pruned heights: %d"
@@ -32,15 +32,15 @@ var (
 
 func NewManager(db dbm.DB, logger log.Logger) *Manager {
 	return &Manager{
-		db: db,
-		logger:       logger,
-		opts:         types.NewPruningOptions(types.PruningNothing),
-		pruneHeights: []int64{},
+		db:             db,
+		logger:         logger,
+		opts:           types.NewPruningOptions(types.PruningNothing),
+		pruneHeights:   []int64{},
 		pruneHeightsMx: sync.Mutex{},
 		// These are the heights that are multiples of snapshotInterval and kept for state sync snapshots.
 		// The heights are added to this list to be pruned when a snapshot is complete.
-		pruneSnapshotHeights: list.New(),
-		pruneSnapshotHeightsMx:                   sync.Mutex{},
+		pruneSnapshotHeights:   list.New(),
+		pruneSnapshotHeightsMx: sync.Mutex{},
 	}
 }
 
@@ -64,14 +64,14 @@ func (m *Manager) GetFlushAndResetPruningHeights() ([]int64, error) {
 	defer m.pruneHeightsMx.Unlock()
 
 	pruningHeights := m.pruneHeights
-	
+
 	// flush the update to disk so that it is not lost if crash happens.
 	if err := m.db.SetSync(pruneHeightsKey, int64SliceToBytes(pruningHeights)); err != nil {
 		return nil, err
 	}
 
 	m.pruneHeights = make([]int64, 0, m.opts.Interval)
-	
+
 	return pruningHeights, nil
 }
 

--- a/pruning/manager_test.go
+++ b/pruning/manager_test.go
@@ -4,9 +4,7 @@ import (
 	"container/list"
 	"fmt"
 
-	"sync"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/tendermint/tendermint/libs/log"
@@ -17,10 +15,12 @@ import (
 )
 
 func TestNewManager(t *testing.T) {
-	manager := pruning.NewManager(log.NewNopLogger())
+	manager := pruning.NewManager(db.NewMemDB(), log.NewNopLogger())
 
 	require.NotNil(t, manager)
-	require.NotNil(t, manager.GetPruningHeights())
+	heights, err := manager.GetFlushAndResetPruningHeights()
+	require.NoError(t, err)
+	require.NotNil(t, heights)
 	require.Equal(t, types.PruningNothing, manager.GetOptions().GetPruningStrategy())
 }
 
@@ -75,7 +75,7 @@ func TestStrategies(t *testing.T) {
 		},
 	}
 
-	manager := pruning.NewManager(log.NewNopLogger())
+	manager := pruning.NewManager(db.NewMemDB(), log.NewNopLogger())
 
 	require.NotNil(t, manager)
 
@@ -112,7 +112,8 @@ func TestStrategies(t *testing.T) {
 				handleHeightActual := manager.HandleHeight(curHeight)
 				shouldPruneAtHeightActual := manager.ShouldPruneAtHeight(curHeight)
 
-				curPruningHeihts := manager.GetPruningHeights()
+				curPruningHeihts, err := manager.GetFlushAndResetPruningHeights()
+				require.Nil(t, err)
 
 				curHeightStr := fmt.Sprintf("height: %d", curHeight)
 
@@ -121,7 +122,9 @@ func TestStrategies(t *testing.T) {
 					require.Equal(t, int64(0), handleHeightActual, curHeightStr)
 					require.False(t, shouldPruneAtHeightActual, curHeightStr)
 
-					require.Equal(t, 0, len(manager.GetPruningHeights()))
+					heights, err := manager.GetFlushAndResetPruningHeights()
+					require.NoError(t, err)
+					require.Equal(t, 0, len(heights))
 				default:
 					if curHeight > int64(curKeepRecent) && (tc.snapshotInterval != 0 && (curHeight-int64(curKeepRecent))%int64(tc.snapshotInterval) != 0 || tc.snapshotInterval == 0) {
 						expectedHeight := curHeight - int64(curKeepRecent)
@@ -131,12 +134,15 @@ func TestStrategies(t *testing.T) {
 					} else {
 						require.Equal(t, int64(0), handleHeightActual, curHeightStr)
 
-						require.Equal(t, 0, len(manager.GetPruningHeights()))
+						heights, err := manager.GetFlushAndResetPruningHeights()
+						require.NoError(t, err)
+						require.Equal(t, 0, len(heights))
 					}
 					require.Equal(t, curHeight%int64(curInterval) == 0, shouldPruneAtHeightActual, curHeightStr)
 				}
-				manager.ResetPruningHeights()
-				require.Equal(t, 0, len(manager.GetPruningHeights()))
+				heights, err := manager.GetFlushAndResetPruningHeights()
+				require.NoError(t, err)
+				require.Equal(t, 0, len(heights))
 			}
 		})
 	}
@@ -185,23 +191,120 @@ func TestHandleHeight_Inputs(t *testing.T) {
 
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
-			manager := pruning.NewManager(log.NewNopLogger())
+			manager := pruning.NewManager(db.NewMemDB(), log.NewNopLogger())
 			require.NotNil(t, manager)
 			manager.SetOptions(types.NewPruningOptions(tc.strategy))
 
 			handleHeightActual := manager.HandleHeight(tc.height)
 			require.Equal(t, tc.expectedResult, handleHeightActual)
 
-			require.Equal(t, tc.expectedHeights, manager.GetPruningHeights())
+			actualHeights, err := manager.GetFlushAndResetPruningHeights()
+			require.NoError(t, err)
+			require.Equal(t, len(tc.expectedHeights), len(actualHeights))
+			require.Equal(t, tc.expectedHeights, actualHeights)
+		})
+	}
+}
+
+func TestHandleHeight_FlushToDisk(t *testing.T) {
+	testcases := map[string]struct {
+		previousHeight int64
+		keepRecent uint64
+		snapshotInterval uint64
+		movedSnapshotHeights []int64
+		expectedHandleHeightResult int64
+		expectedLoadPruningHeightsResult error
+		expectedLoadedHeights []int64
+	}{
+		"simple flush occurs": {
+			previousHeight: 11,
+			keepRecent: 10,
+			snapshotInterval: 0,
+			movedSnapshotHeights: []int64{},
+			expectedHandleHeightResult: 11 - 10,
+			expectedLoadPruningHeightsResult: nil,
+			expectedLoadedHeights: []int64{11 - 10},
+		},
+		"previous height <= keep recent - no update and no flush": {
+			previousHeight: 9,
+			keepRecent: 10,
+			snapshotInterval: 0,
+			movedSnapshotHeights: []int64{},
+			expectedHandleHeightResult: 0,
+			expectedLoadPruningHeightsResult: nil,
+			expectedLoadedHeights: []int64{},
+		},
+		"previous height alligns with snapshot interval - no update and no flush": {
+			previousHeight: 12,
+			keepRecent: 10,
+			snapshotInterval: 2,
+			movedSnapshotHeights: []int64{},
+			expectedHandleHeightResult: 0,
+			expectedLoadPruningHeightsResult: nil,
+			expectedLoadedHeights: []int64{},
+		},
+		"previous height does not align with snapshot interval - flush": {
+			previousHeight: 12,
+			keepRecent: 10,
+			snapshotInterval: 3,
+			movedSnapshotHeights: []int64{},
+			expectedHandleHeightResult: 2,
+			expectedLoadPruningHeightsResult: nil,
+			expectedLoadedHeights: []int64{2},
+		},
+		"moved snapshot heights - flushed": {
+			previousHeight: 32,
+			keepRecent: 10,
+			snapshotInterval: 5,
+			movedSnapshotHeights: []int64{15, 20, 25},
+			expectedHandleHeightResult: 22,
+			expectedLoadPruningHeightsResult: nil,
+			expectedLoadedHeights: []int64{15, 20, 22},
+		},
+		"previous height alligns with snapshot interval - no update but flush snapshot heights": {
+			previousHeight: 30,
+			keepRecent: 10,
+			snapshotInterval: 5,
+			movedSnapshotHeights: []int64{15, 20, 25},
+			expectedHandleHeightResult: 0,
+			expectedLoadPruningHeightsResult: nil,
+			expectedLoadedHeights: []int64{15},
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			// Setup
+			db := db.NewMemDB()
+			manager := pruning.NewManager(db, log.NewNopLogger())
+			require.NotNil(t, manager)
+
+			manager.SetSnapshotInterval(tc.snapshotInterval)
+			manager.SetOptions(types.NewCustomPruningOptions(uint64(tc.keepRecent), uint64(10)))
+
+			for _, snapshotHeight := range tc.movedSnapshotHeights {
+				manager.HandleHeightSnapshot(snapshotHeight)
+			}
+
+			// Test
+			handleHeightActual := manager.HandleHeight(tc.previousHeight)
+			require.Equal(t, tc.expectedHandleHeightResult, handleHeightActual)
+
+			err := manager.LoadPruningHeights(db)
+			require.NoError(t, err)
+
+			heights, err := manager.GetFlushAndResetPruningHeights()
+			require.NoError(t, err)
+			require.Equal(t, len(tc.expectedLoadedHeights), len(heights))
+			require.ElementsMatch(t, tc.expectedLoadedHeights, heights)
 		})
 	}
 }
 
 func TestFlushLoad(t *testing.T) {
-	manager := pruning.NewManager(log.NewNopLogger())
-	require.NotNil(t, manager)
-
 	db := db.NewMemDB()
+	manager := pruning.NewManager(db, log.NewNopLogger())
+	require.NotNil(t, manager)
 
 	curStrategy := types.NewCustomPruningOptions(100, 15)
 
@@ -228,32 +331,28 @@ func TestFlushLoad(t *testing.T) {
 			require.Equal(t, int64(0), handleHeightActual, curHeightStr)
 		}
 
-		if manager.ShouldPruneAtHeight(curHeight) {
-			manager.ResetPruningHeights()
-			heightsToPruneMirror = make([]int64, 0)
-		}
-
-		// N.B.: There is no reason behind the choice of 3.
-		if curHeight%3 == 0 {
-			require.Equal(t, heightsToPruneMirror, manager.GetPruningHeights(), curHeightStr)
-			batch := db.NewBatch()
-			manager.FlushPruningHeights(batch)
-			require.NoError(t, batch.Write())
-			require.NoError(t, batch.Close())
-
-			manager.ResetPruningHeights()
-			require.Equal(t, make([]int64, 0), manager.GetPruningHeights(), curHeightStr)
-
-			err := manager.LoadPruningHeights(db)
+		if manager.ShouldPruneAtHeight(curHeight) && curHeight > int64(keepRecent) {
+			actualHeights, err := manager.GetFlushAndResetPruningHeights()
 			require.NoError(t, err)
-			require.Equal(t, heightsToPruneMirror, manager.GetPruningHeights(), curHeightStr)
+			require.Equal(t, len(heightsToPruneMirror), len(actualHeights))
+			require.Equal(t, heightsToPruneMirror, actualHeights)
+
+			err = manager.LoadPruningHeights(db)
+			require.NoError(t, err)
+
+			actualHeights, err = manager.GetFlushAndResetPruningHeights()
+			require.NoError(t, err)
+			require.Equal(t, len(heightsToPruneMirror), len(actualHeights))
+			require.Equal(t, heightsToPruneMirror, actualHeights)
+
+			heightsToPruneMirror = make([]int64, 0)
 		}
 	}
 }
 
 func TestLoadPruningHeights(t *testing.T) {
 	var (
-		manager = pruning.NewManager(log.NewNopLogger())
+		manager = pruning.NewManager(db.NewMemDB(), log.NewNopLogger())
 		err     error
 	)
 	require.NotNil(t, manager)
@@ -323,86 +422,10 @@ func TestLoadPruningHeights(t *testing.T) {
 }
 
 func TestLoadPruningHeights_PruneNothing(t *testing.T) {
-	var manager = pruning.NewManager(log.NewNopLogger())
+	var manager = pruning.NewManager(db.NewMemDB(), log.NewNopLogger())
 	require.NotNil(t, manager)
 
 	manager.SetOptions(types.NewPruningOptions(types.PruningNothing))
 
 	require.Nil(t, manager.LoadPruningHeights(db.NewMemDB()))
-}
-
-func TestWithSnapshot(t *testing.T) {
-	manager := pruning.NewManager(log.NewNopLogger())
-	require.NotNil(t, manager)
-
-	curStrategy := types.NewCustomPruningOptions(10, 10)
-
-	snapshotInterval := uint64(15)
-	manager.SetSnapshotInterval(snapshotInterval)
-
-	manager.SetOptions(curStrategy)
-	require.Equal(t, curStrategy, manager.GetOptions())
-
-	keepRecent := curStrategy.KeepRecent
-
-	heightsToPruneMirror := make([]int64, 0)
-
-	mx := sync.Mutex{}
-	snapshotHeightsToPruneMirror := list.New()
-
-	wg := sync.WaitGroup{}
-	defer wg.Wait()
-
-	for curHeight := int64(1); curHeight < 100000; curHeight++ {
-		mx.Lock()
-		handleHeightActual := manager.HandleHeight(curHeight)
-
-		curHeightStr := fmt.Sprintf("height: %d", curHeight)
-
-		if curHeight > int64(keepRecent) && (curHeight-int64(keepRecent))%int64(snapshotInterval) != 0 {
-			expectedHandleHeight := curHeight - int64(keepRecent)
-			require.Equal(t, expectedHandleHeight, handleHeightActual, curHeightStr)
-			heightsToPruneMirror = append(heightsToPruneMirror, expectedHandleHeight)
-		} else {
-			require.Equal(t, int64(0), handleHeightActual, curHeightStr)
-		}
-
-		actualHeightsToPrune := manager.GetPruningHeights()
-
-		var next *list.Element
-		for e := snapshotHeightsToPruneMirror.Front(); e != nil; e = next {
-			snapshotHeight := e.Value.(int64)
-			if snapshotHeight < curHeight-int64(keepRecent) {
-				heightsToPruneMirror = append(heightsToPruneMirror, snapshotHeight)
-
-				// We must get next before removing to be able to continue iterating.
-				next = e.Next()
-				snapshotHeightsToPruneMirror.Remove(e)
-			} else {
-				next = e.Next()
-			}
-		}
-
-		require.Equal(t, heightsToPruneMirror, actualHeightsToPrune, curHeightStr)
-		mx.Unlock()
-
-		if manager.ShouldPruneAtHeight(curHeight) {
-			manager.ResetPruningHeights()
-			heightsToPruneMirror = make([]int64, 0)
-		}
-
-		// Mimic taking snapshots in the background
-		if curHeight%int64(snapshotInterval) == 0 {
-			wg.Add(1)
-			go func(curHeightCp int64) {
-				time.Sleep(time.Nanosecond * 500)
-
-				mx.Lock()
-				manager.HandleHeightSnapshot(curHeightCp)
-				snapshotHeightsToPruneMirror.PushBack(curHeightCp)
-				mx.Unlock()
-				wg.Done()
-			}(curHeight)
-		}
-	}
 }

--- a/pruning/manager_test.go
+++ b/pruning/manager_test.go
@@ -152,9 +152,9 @@ func TestHandleHeight_Inputs(t *testing.T) {
 	var keepRecent int64 = int64(types.NewPruningOptions(types.PruningEverything).KeepRecent)
 
 	testcases := map[string]struct {
-		height int64
-		expectedResult int64
-		strategy types.PruningStrategy
+		height          int64
+		expectedResult  int64
+		strategy        types.PruningStrategy
 		expectedHeights []int64
 	}{
 		"previousHeight is negative - prune everything - invalid previousHeight": {
@@ -208,67 +208,67 @@ func TestHandleHeight_Inputs(t *testing.T) {
 
 func TestHandleHeight_FlushLoadFromDisk(t *testing.T) {
 	testcases := map[string]struct {
-		previousHeight int64
-		keepRecent uint64
-		snapshotInterval uint64
-		movedSnapshotHeights []int64
-		expectedHandleHeightResult int64
+		previousHeight                   int64
+		keepRecent                       uint64
+		snapshotInterval                 uint64
+		movedSnapshotHeights             []int64
+		expectedHandleHeightResult       int64
 		expectedLoadPruningHeightsResult error
-		expectedLoadedHeights []int64
+		expectedLoadedHeights            []int64
 	}{
 		"simple flush occurs": {
-			previousHeight: 11,
-			keepRecent: 10,
-			snapshotInterval: 0,
-			movedSnapshotHeights: []int64{},
-			expectedHandleHeightResult: 11 - 10,
+			previousHeight:                   11,
+			keepRecent:                       10,
+			snapshotInterval:                 0,
+			movedSnapshotHeights:             []int64{},
+			expectedHandleHeightResult:       11 - 10,
 			expectedLoadPruningHeightsResult: nil,
-			expectedLoadedHeights: []int64{11 - 10},
+			expectedLoadedHeights:            []int64{11 - 10},
 		},
 		"previous height <= keep recent - no update and no flush": {
-			previousHeight: 9,
-			keepRecent: 10,
-			snapshotInterval: 0,
-			movedSnapshotHeights: []int64{},
-			expectedHandleHeightResult: 0,
+			previousHeight:                   9,
+			keepRecent:                       10,
+			snapshotInterval:                 0,
+			movedSnapshotHeights:             []int64{},
+			expectedHandleHeightResult:       0,
 			expectedLoadPruningHeightsResult: nil,
-			expectedLoadedHeights: []int64{},
+			expectedLoadedHeights:            []int64{},
 		},
 		"previous height alligns with snapshot interval - no update and no flush": {
-			previousHeight: 12,
-			keepRecent: 10,
-			snapshotInterval: 2,
-			movedSnapshotHeights: []int64{},
-			expectedHandleHeightResult: 0,
+			previousHeight:                   12,
+			keepRecent:                       10,
+			snapshotInterval:                 2,
+			movedSnapshotHeights:             []int64{},
+			expectedHandleHeightResult:       0,
 			expectedLoadPruningHeightsResult: nil,
-			expectedLoadedHeights: []int64{},
+			expectedLoadedHeights:            []int64{},
 		},
 		"previous height does not align with snapshot interval - flush": {
-			previousHeight: 12,
-			keepRecent: 10,
-			snapshotInterval: 3,
-			movedSnapshotHeights: []int64{},
-			expectedHandleHeightResult: 2,
+			previousHeight:                   12,
+			keepRecent:                       10,
+			snapshotInterval:                 3,
+			movedSnapshotHeights:             []int64{},
+			expectedHandleHeightResult:       2,
 			expectedLoadPruningHeightsResult: nil,
-			expectedLoadedHeights: []int64{2},
+			expectedLoadedHeights:            []int64{2},
 		},
 		"moved snapshot heights - flushed": {
-			previousHeight: 32,
-			keepRecent: 10,
-			snapshotInterval: 5,
-			movedSnapshotHeights: []int64{15, 20, 25},
-			expectedHandleHeightResult: 22,
+			previousHeight:                   32,
+			keepRecent:                       10,
+			snapshotInterval:                 5,
+			movedSnapshotHeights:             []int64{15, 20, 25},
+			expectedHandleHeightResult:       22,
 			expectedLoadPruningHeightsResult: nil,
-			expectedLoadedHeights: []int64{15, 20, 22},
+			expectedLoadedHeights:            []int64{15, 20, 22},
 		},
 		"previous height alligns with snapshot interval - no update but flush snapshot heights": {
-			previousHeight: 30,
-			keepRecent: 10,
-			snapshotInterval: 5,
-			movedSnapshotHeights: []int64{15, 20, 25},
-			expectedHandleHeightResult: 0,
+			previousHeight:                   30,
+			keepRecent:                       10,
+			snapshotInterval:                 5,
+			movedSnapshotHeights:             []int64{15, 20, 25},
+			expectedHandleHeightResult:       0,
 			expectedLoadPruningHeightsResult: nil,
-			expectedLoadedHeights: []int64{15},
+			expectedLoadedHeights:            []int64{15},
 		},
 	}
 
@@ -319,7 +319,7 @@ func TestHandleHeightSnapshot_FlushLoadFromDisk(t *testing.T) {
 	for snapshotHeight := int64(-1); snapshotHeight < 100; snapshotHeight++ {
 		// Test flush
 		manager.HandleHeightSnapshot(snapshotHeight)
-		
+
 		// Post test
 		if snapshotHeight > 0 {
 			loadedHeightsMirror = append(loadedHeightsMirror, snapshotHeight)

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -556,11 +556,11 @@ func (rs *Store) pruneStores() error {
 	}
 
 	if len(pruningHeights) == 0 {
-		rs.logger.Debug("pruning skipped, no heights to prune")
+		rs.logger.Debug("pruning skipped; no heights to prune")
 		return nil
 	}
 
-	rs.logger.Debug(fmt.Sprintf("pruning the following heights: %v\n", pruningHeights))
+	rs.logger.Debug("pruning heights", "heights", pruningHeights)
 
 	for key, store := range rs.stores {
 		// If the store is wrapped with an inter-block cache, we must first unwrap

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -968,7 +968,6 @@ func (rs *Store) flushMetadata(db dbm.DB, version int64, cInfo *types.CommitInfo
 	}
 
 	flushLatestVersion(batch, version)
-	// rs.pruningManager.FlushPruningHeights(batch)
 
 	if err := batch.WriteSync(); err != nil {
 		panic(fmt.Errorf("error on batch write %w", err))

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -79,7 +79,7 @@ func NewStore(db dbm.DB, logger log.Logger) *Store {
 		keysByName:     make(map[string]types.StoreKey),
 		listeners:      make(map[types.StoreKey][]types.WriteListener),
 		removalMap:     make(map[types.StoreKey]bool),
-		pruningManager: pruning.NewManager(logger),
+		pruningManager: pruning.NewManager(db, logger),
 	}
 }
 
@@ -550,12 +550,17 @@ func (rs *Store) handlePruning(version int64) error {
 }
 
 func (rs *Store) pruneStores() error {
-	pruningHeights := rs.pruningManager.GetPruningHeights()
-	rs.logger.Debug(fmt.Sprintf("pruning the following heights: %v\n", pruningHeights))
+	pruningHeights, err := rs.pruningManager.GetFlushAndResetPruningHeights()
+	if err != nil {
+		return err
+	}
 
 	if len(pruningHeights) == 0 {
+		rs.logger.Debug("pruning skipped, no heights to prune")
 		return nil
 	}
+
+	rs.logger.Debug(fmt.Sprintf("pruning the following heights: %v\n", pruningHeights))
 
 	for key, store := range rs.stores {
 		// If the store is wrapped with an inter-block cache, we must first unwrap
@@ -575,7 +580,6 @@ func (rs *Store) pruneStores() error {
 			return err
 		}
 	}
-	rs.pruningManager.ResetPruningHeights()
 	return nil
 }
 
@@ -964,7 +968,7 @@ func (rs *Store) flushMetadata(db dbm.DB, version int64, cInfo *types.CommitInfo
 	}
 
 	flushLatestVersion(batch, version)
-	rs.pruningManager.FlushPruningHeights(batch)
+	// rs.pruningManager.FlushPruningHeights(batch)
 
 	if err := batch.WriteSync(); err != nil {
 		panic(fmt.Errorf("error on batch write %w", err))

--- a/store/rootmulti/store_test.go
+++ b/store/rootmulti/store_test.go
@@ -510,13 +510,13 @@ func TestMultiStore_Pruning(t *testing.T) {
 
 func TestMultiStore_Pruning_SameHeightsTwice(t *testing.T) {
 	const (
-		numVersions int64 = 10
-		keepRecent uint64 = 2
-		interval uint64 = 10
+		numVersions int64  = 10
+		keepRecent  uint64 = 2
+		interval    uint64 = 10
 	)
 
 	expectedHeights := []int64{}
-	for i := int64(1); i < numVersions - int64(keepRecent); i++ {
+	for i := int64(1); i < numVersions-int64(keepRecent); i++ {
 		expectedHeights = append(expectedHeights, i)
 	}
 
@@ -532,7 +532,7 @@ func TestMultiStore_Pruning_SameHeightsTwice(t *testing.T) {
 
 	require.Equal(t, numVersions, lastCommitInfo.Version)
 
-	for v := int64(1); v < numVersions - int64(keepRecent); v++ {
+	for v := int64(1); v < numVersions-int64(keepRecent); v++ {
 		err := ms.LoadVersion(v)
 		require.Error(t, err, "expected error when loading pruned height: %d", v)
 	}
@@ -559,7 +559,7 @@ func TestMultiStore_Pruning_SameHeightsTwice(t *testing.T) {
 
 	// Ensure that can commit one more height with no panic
 	lastCommitInfo = ms.Commit()
-	require.Equal(t, numVersions + 1, lastCommitInfo.Version)
+	require.Equal(t, numVersions+1, lastCommitInfo.Version)
 }
 
 func TestMultiStore_PruningRestart(t *testing.T) {

--- a/store/rootmulti/store_test.go
+++ b/store/rootmulti/store_test.go
@@ -508,6 +508,60 @@ func TestMultiStore_Pruning(t *testing.T) {
 	}
 }
 
+func TestMultiStore_Pruning_SameHeightsTwice(t *testing.T) {
+	const (
+		numVersions int64 = 10
+		keepRecent uint64 = 2
+		interval uint64 = 10
+	)
+
+	expectedHeights := []int64{}
+	for i := int64(1); i < numVersions - int64(keepRecent); i++ {
+		expectedHeights = append(expectedHeights, i)
+	}
+
+	db := dbm.NewMemDB()
+
+	ms := newMultiStoreWithMounts(db, pruningtypes.NewCustomPruningOptions(keepRecent, interval))
+	require.NoError(t, ms.LoadLatestVersion())
+
+	var lastCommitInfo types.CommitID
+	for i := int64(0); i < numVersions; i++ {
+		lastCommitInfo = ms.Commit()
+	}
+
+	require.Equal(t, numVersions, lastCommitInfo.Version)
+
+	for v := int64(1); v < numVersions - int64(keepRecent); v++ {
+		err := ms.LoadVersion(v)
+		require.Error(t, err, "expected error when loading pruned height: %d", v)
+	}
+
+	for v := int64(numVersions - int64(keepRecent)); v < numVersions; v++ {
+		err := ms.LoadVersion(v)
+		require.NoError(t, err, "expected no error when loading height: %d", v)
+	}
+
+	// Get latest
+	err := ms.LoadVersion(numVersions - 1)
+	require.NoError(t, err)
+
+	// Ensure already pruned heights were loaded
+	heights, err := ms.pruningManager.GetFlushAndResetPruningHeights()
+	require.NoError(t, err)
+	require.Equal(t, expectedHeights, heights)
+
+	require.NoError(t, ms.pruningManager.LoadPruningHeights(db))
+
+	// Test pruning the same heights again
+	lastCommitInfo = ms.Commit()
+	require.Equal(t, numVersions, lastCommitInfo.Version)
+
+	// Ensure that can commit one more height with no panic
+	lastCommitInfo = ms.Commit()
+	require.Equal(t, numVersions + 1, lastCommitInfo.Version)
+}
+
 func TestMultiStore_PruningRestart(t *testing.T) {
 	db := dbm.NewMemDB()
 	ms := newMultiStoreWithMounts(db, pruningtypes.NewCustomPruningOptions(2, 11))
@@ -528,7 +582,8 @@ func TestMultiStore_PruningRestart(t *testing.T) {
 
 	actualHeightsToPrune, err := ms.pruningManager.GetFlushAndResetPruningHeights()
 	require.NoError(t, err)
-	require.Equal(t, pruneHeights, len(actualHeightsToPrune))
+	require.Equal(t, len(pruneHeights), len(actualHeightsToPrune))
+	require.Equal(t, pruneHeights, actualHeightsToPrune)
 
 	// "restart"
 	ms = newMultiStoreWithMounts(db, pruningtypes.NewCustomPruningOptions(2, 11))

--- a/store/rootmulti/store_test.go
+++ b/store/rootmulti/store_test.go
@@ -593,7 +593,7 @@ func TestMultiStore_PruningRestart(t *testing.T) {
 
 	actualHeightsToPrune, err = ms.pruningManager.GetFlushAndResetPruningHeights()
 	require.NoError(t, err)
-	require.Equal(t, pruneHeights, len(actualHeightsToPrune))
+	require.Equal(t, pruneHeights, actualHeightsToPrune)
 
 	// commit one more block and ensure the heights have been pruned
 	ms.Commit()


### PR DESCRIPTION
## Description

This PR is a follow-up to: https://github.com/cosmos/cosmos-sdk/pull/11496#discussion_r846829628

It mitigates the risk of soundness bugs / data races by synchronizing access to all members of the pruning manager and making some operations atomic. For example, GetHeights, FlushHeights and ResetHeights was merged into one `GetFlushAndResetPruningHeights`. 

In addition, it addresses another previously known issue: https://github.com/osmosis-labs/cosmos-sdk/issues/149
   * Now, the pruning heights are flushed to disk immediately, eliminating the risk of losing data on crash and not pruning some heights

Updated unit tests to reflect all changes. Also, added a unit test to attempt pruning the same heights twice.