### PR TITLE
fix: add tendermint command

### DIFF
--- a/server/util.go
+++ b/server/util.go
@@ -282,6 +282,7 @@ func AddCommands(rootCmd *cobra.Command, defaultNodeHome string, appCreator type
 	rootCmd.AddCommand(
 		startCmd,
 		tmcmd.ResetAllCmd,
+		tendermintCmd,
 		ExportCmd(appExport, defaultNodeHome),
 		version.NewVersionCommand(),
 	)


### PR DESCRIPTION
This PR re-adds the tendermint commands to the CLI. I tested this locally and acts as expected.