### PR TITLE
fix: concurrency issues between simulation, grpc queries and ABCI commit flow

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -607,7 +607,7 @@ func (app *BaseApp) createQueryContext(height int64, prove bool) (sdk.Context, e
 		return sdk.Context{},
 			sdkerrors.Wrapf(
 				sdkerrors.ErrInvalidRequest,
-				"failed to load state at height %d; %s (latest height: %d)", height, app.LastBlockHeight(),
+				"failed to load state at height %d; (latest height: %d)", height, app.LastBlockHeight(),
 			)
 	}
 

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -613,7 +613,7 @@ func (app *BaseApp) createQueryContext(height int64, prove bool) (sdk.Context, e
 
 	cacheMS, err := app.cms.CacheMultiStoreWithVersion(height)
 	if err != nil {
-		return sdk.Context{}, err
+		return sdk.Context{}, fmt.Errorf("failed to load cache multi store for height %d: %w", height, err)
 	}
 
 	// branch the commit-multistore for safety

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -603,13 +603,17 @@ func (app *BaseApp) createQueryContext(height int64, prove bool) (sdk.Context, e
 			)
 	}
 
-	cacheMS, err := app.cms.CacheMultiStoreWithVersion(height)
-	if err != nil {
+	if height > app.LastBlockHeight() {
 		return sdk.Context{},
 			sdkerrors.Wrapf(
 				sdkerrors.ErrInvalidRequest,
-				"failed to load state at height %d; %s (latest height: %d)", height, err, app.LastBlockHeight(),
+				"failed to load state at height %d; %s (latest height: %d)", height, app.LastBlockHeight(),
 			)
+	}
+
+	cacheMS, err := app.cms.CacheMultiStoreWithVersion(height)
+	if err != nil {
+		return sdk.Context{}, err
 	}
 
 	// branch the commit-multistore for safety

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -603,11 +603,12 @@ func (app *BaseApp) createQueryContext(height int64, prove bool) (sdk.Context, e
 			)
 	}
 
-	if height > app.LastBlockHeight() {
+	lastBlockHeight := app.LastBlockHeight()
+	if height > lastBlockHeight {
 		return sdk.Context{},
 			sdkerrors.Wrapf(
 				sdkerrors.ErrInvalidRequest,
-				"failed to load state at height %d; (latest height: %d)", height, app.LastBlockHeight(),
+				"failed to load state at height %d; (latest height: %d)", height, lastBlockHeight,
 			)
 	}
 

--- a/client/export_test.go
+++ b/client/export_test.go
@@ -1,0 +1,5 @@
+package client
+
+var (
+	SelectHeight = selectHeight
+)

--- a/client/grpc_query.go
+++ b/client/grpc_query.go
@@ -122,13 +122,15 @@ func (Context) NewStream(gocontext.Context, *grpc.StreamDesc, string, ...grpc.Ca
 
 // selectHeight returns the height chosen from client context and grpc context.
 // If exists, height extracted from grpcCtx takes precedence.
-func selectHeight(clientContext Context, grpcCtx gocontext.Context) (height int64, err error) {
+func selectHeight(clientContext Context, grpcCtx gocontext.Context) (int64, error) {
+	var height int64
 	if clientContext.Height > 0 {
 		height = clientContext.Height
 	}
 
 	md, _ := metadata.FromOutgoingContext(grpcCtx)
 	if heights := md.Get(grpctypes.GRPCBlockHeightHeader); len(heights) > 0 {
+		var err error
 		height, err = strconv.ParseInt(heights[0], 10, 64)
 		if err != nil {
 			return 0, err

--- a/client/grpc_query.go
+++ b/client/grpc_query.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"strings"
 
 	gogogrpc "github.com/gogo/protobuf/grpc"
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -51,9 +52,23 @@ func (ctx Context) Invoke(grpcCtx gocontext.Context, method string, req, reply i
 		return err
 	}
 
-	if ctx.GRPCClient != nil {
+	// Certain queries must not be be concurrent with ABCI to function correctly.
+	// As a result, we direct them to the ABCI flow where they get syncronized.
+	_, isSimulationRequest := req.(*tx.SimulateRequest)
+	isTendermintQuery := strings.Contains(method, "tendermint")
+
+	isGRPCAllowed := !isTendermintQuery && !isSimulationRequest
+
+	requestedHeight, err := selectHeight(ctx, grpcCtx)
+	if err != nil {
+		return err
+	}
+
+	if ctx.GRPCClient != nil && isGRPCAllowed {
+		md := metadata.Pairs(grpctypes.GRPCBlockHeightHeader, strconv.FormatInt(requestedHeight, 10))
+		context := metadata.NewOutgoingContext(grpcCtx, md)
 		// Case 2-1. Invoke grpc.
-		return ctx.GRPCClient.Invoke(grpcCtx, method, req, reply, opts...)
+		return ctx.GRPCClient.Invoke(context, method, req, reply, opts...)
 	}
 
 	// Case 2-2. Querying state via abci query.
@@ -62,26 +77,10 @@ func (ctx Context) Invoke(grpcCtx gocontext.Context, method string, req, reply i
 		return err
 	}
 
-	// parse height header
-	md, _ := metadata.FromOutgoingContext(grpcCtx)
-	if heights := md.Get(grpctypes.GRPCBlockHeightHeader); len(heights) > 0 {
-		height, err := strconv.ParseInt(heights[0], 10, 64)
-		if err != nil {
-			return err
-		}
-		if height < 0 {
-			return sdkerrors.Wrapf(
-				sdkerrors.ErrInvalidRequest,
-				"client.Context.Invoke: height (%d) from %q must be >= 0", height, grpctypes.GRPCBlockHeightHeader)
-		}
-
-		ctx = ctx.WithHeight(height)
-	}
-
 	abciReq := abci.RequestQuery{
 		Path:   method,
 		Data:   reqBz,
-		Height: ctx.Height,
+		Height: requestedHeight,
 	}
 
 	res, err := ctx.QueryABCI(abciReq)
@@ -99,7 +98,7 @@ func (ctx Context) Invoke(grpcCtx gocontext.Context, method string, req, reply i
 	// We then parse all the call options, if the call option is a
 	// HeaderCallOption, then we manually set the value of that header to the
 	// metadata.
-	md = metadata.Pairs(grpctypes.GRPCBlockHeightHeader, strconv.FormatInt(res.Height, 10))
+	md := metadata.Pairs(grpctypes.GRPCBlockHeightHeader, strconv.FormatInt(res.Height, 10))
 	for _, callOpt := range opts {
 		header, ok := callOpt.(grpc.HeaderCallOption)
 		if !ok {
@@ -119,4 +118,21 @@ func (ctx Context) Invoke(grpcCtx gocontext.Context, method string, req, reply i
 // NewStream implements the grpc ClientConn.NewStream method
 func (Context) NewStream(gocontext.Context, *grpc.StreamDesc, string, ...grpc.CallOption) (grpc.ClientStream, error) {
 	return nil, fmt.Errorf("streaming rpc not supported")
+}
+
+// selectHeight returns the height chosen from client context and grpc context.
+// If exists, height extracted from grpcCtx takes precedence.
+func selectHeight(clientContext Context, grpcCtx gocontext.Context) (height int64, err error) {
+	if clientContext.Height > 0 {
+		height = clientContext.Height
+	}
+
+	md, _ := metadata.FromOutgoingContext(grpcCtx)
+	if heights := md.Get(grpctypes.GRPCBlockHeightHeader); len(heights) > 0 {
+		height, err = strconv.ParseInt(heights[0], 10, 64)
+		if err != nil {
+			return 0, err
+		}
+	}
+	return height, nil
 }

--- a/client/grpc_query_test.go
+++ b/client/grpc_query_test.go
@@ -1,5 +1,3 @@
-// +build norace
-
 package client_test
 
 import (
@@ -7,10 +5,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 
+	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/testutil/network"
 	"github.com/cosmos/cosmos-sdk/testutil/testdata"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -79,4 +79,55 @@ func (s *IntegrationTestSuite) TestGRPCQuery() {
 
 func TestIntegrationTestSuite(t *testing.T) {
 	suite.Run(t, new(IntegrationTestSuite))
+}
+
+func TestSelectHeight(t *testing.T) {
+	// if height is set to this, the tests assume that it is not set
+	const heightNotSetFlag = int64(-1)
+
+	testcases := map[string]struct {
+		clientContextHeight int64
+		grpcHeight          int64
+		expectedHeight      int64
+	}{
+		"clientContextHeight 1; grpcHeight not set - clientContextHeight selected": {
+			clientContextHeight: 1,
+			grpcHeight:          heightNotSetFlag,
+			expectedHeight:      1,
+		},
+		"clientContextHeight not set; grpcHeight is 2 - grpcHeight is chosen": {
+			clientContextHeight: heightNotSetFlag,
+			grpcHeight:          2,
+			expectedHeight:      2,
+		},
+		"both not set - 0 returned": {
+			clientContextHeight: heightNotSetFlag,
+			grpcHeight:          heightNotSetFlag,
+			expectedHeight:      0,
+		},
+		"clientContextHeight 3; grpcHeight is 0 - grpcHeight is chosen": {
+			clientContextHeight: 3,
+			grpcHeight:          0,
+			expectedHeight:      0,
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			clientCtx := client.Context{}
+			if tc.clientContextHeight != heightNotSetFlag {
+				clientCtx = clientCtx.WithHeight(tc.clientContextHeight)
+			}
+
+			grpcContxt := context.Background()
+			if tc.grpcHeight != heightNotSetFlag {
+				header := metadata.Pairs(grpctypes.GRPCBlockHeightHeader, fmt.Sprintf("%d", tc.grpcHeight))
+				grpcContxt = metadata.NewOutgoingContext(grpcContxt, header)
+			}
+
+			height, err := client.SelectHeight(clientCtx, grpcContxt)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedHeight, height)
+		})
+	}
 }

--- a/client/grpc_query_test.go
+++ b/client/grpc_query_test.go
@@ -31,13 +31,13 @@ type testcase struct {
 }
 
 const (
-	// if this height is set to clientContextHeight or grpcHeight testcase,
-	// the test assumes that it is not set.
+	// if clientContextHeight or grpcHeight is set to this flag,
+	// the test assumes that the respective height is not provided.
 	heightNotSetFlag = int64(-1)
 	// given the current block time, this should never be reached by the time
 	// a test is run.
 	invalidBeyondLatestHeight = 1_000_000_000
-	// if this flag is set to expectedHeight, error is assummed.
+	// if this flag is set to expectedHeight, an error is assumed.
 	errorHeightFlag = int64(-2)
 )
 

--- a/testutil/network/network.go
+++ b/testutil/network/network.go
@@ -76,6 +76,7 @@ type Config struct {
 	InterfaceRegistry codectypes.InterfaceRegistry
 
 	TxConfig         client.TxConfig
+	GRPCConfig       srvconfig.GRPCConfig
 	AccountRetriever client.AccountRetriever
 	AppConstructor   AppConstructor             // the ABCI application constructor
 	GenesisState     map[string]json.RawMessage // custom gensis state to provide

--- a/testutil/network/network.go
+++ b/testutil/network/network.go
@@ -76,7 +76,6 @@ type Config struct {
 	InterfaceRegistry codectypes.InterfaceRegistry
 
 	TxConfig         client.TxConfig
-	GRPCConfig       srvconfig.GRPCConfig
 	AccountRetriever client.AccountRetriever
 	AppConstructor   AppConstructor             // the ABCI application constructor
 	GenesisState     map[string]json.RawMessage // custom gensis state to provide

--- a/x/auth/tx/service_test.go
+++ b/x/auth/tx/service_test.go
@@ -98,31 +98,34 @@ func (s IntegrationTestSuite) TestSimulateTx_GRPC() {
 	s.Require().NoError(err)
 
 	testCases := []struct {
-		name      string
-		req       *tx.SimulateRequest
-		expErr    bool
-		expErrMsg string
+		name        string
+		req         *tx.SimulateRequest
+		expErr      bool
+		expErrMsg   string
+		repeatCount int
 	}{
-		{"nil request", nil, true, "request cannot be nil"},
-		{"empty request", &tx.SimulateRequest{}, true, "empty txBytes is not allowed"},
-		{"valid request with proto tx (deprecated)", &tx.SimulateRequest{Tx: protoTx}, false, ""},
-		{"valid request with tx_bytes", &tx.SimulateRequest{TxBytes: txBytes}, false, ""},
+		{"nil request", nil, true, "request cannot be nil", 1},
+		{"empty request", &tx.SimulateRequest{}, true, "empty txBytes is not allowed", 1},
+		{"valid request with proto tx (deprecated)", &tx.SimulateRequest{Tx: protoTx}, false, "", 1},
+		{"valid request with tx_bytes", &tx.SimulateRequest{TxBytes: txBytes}, false, "", 1000},
 	}
 
 	for _, tc := range testCases {
 		tc := tc
 		s.Run(tc.name, func() {
-			// Broadcast the tx via gRPC via the validator's clientCtx (which goes
-			// through Tendermint).
-			res, err := s.queryClient.Simulate(context.Background(), tc.req)
-			if tc.expErr {
-				s.Require().Error(err)
-				s.Require().Contains(err.Error(), tc.expErrMsg)
-			} else {
-				s.Require().NoError(err)
-				// Check the result and gas used are correct.
-				s.Require().Equal(len(res.GetResult().GetEvents()), 6) // 1 coin recv 1 coin spent, 1 transfer, 3 messages.
-				s.Require().True(res.GetGasInfo().GetGasUsed() > 0)    // Gas used sometimes change, just check it's not empty.
+			for i := 0; i < tc.repeatCount; i++ {
+				// Broadcast the tx via gRPC via the validator's clientCtx (which goes
+				// through Tendermint).
+				res, err := s.queryClient.Simulate(context.Background(), tc.req)
+				if tc.expErr {
+					s.Require().Error(err)
+					s.Require().Contains(err.Error(), tc.expErrMsg)
+				} else {
+					s.Require().NoError(err)
+					// Check the result and gas used are correct.
+					s.Require().Equal(len(res.GetResult().GetEvents()), 6) // 1 coin recv 1 coin spent, 1 transfer, 3 messages.
+					s.Require().True(res.GetGasInfo().GetGasUsed() > 0)    // Gas used sometimes change, just check it's not empty.
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Description
Fixes the problem in: https://github.com/osmosis-labs/osmosis/issues/1356

Previously, queries were always directed to ABCI, getting eventually synchronized with the commit flow. In #137 , we allowed GRPC queries to be concurrent with the ABCI commit flow. However, integration tests were not configured correctly to test that update. Specifically, the GRPC client was never set up in the integration suite. As a result, the flow with concurrent GRPC queries was never tested.

Upon setting up the GRPC client correctly `in testutil/network/util.go`, 2 problems were exposed:
1. A number of data races across multiple GRPC queries and simulation unit tests
2. In some cases, the requested height was never propagated correctly by the GRPC call in the client. As a result, the GRPC server never read the requested height and always assumed the latest. According to the current design, height may come from `grpc context` or `client context`. Currently, if the caller provided height through `grpc context`, that would work. However, it wouldn't if they attempted to supply it via the `client context`, similar to how [integration tests currently do](https://github.com/osmosis-labs/cosmos-sdk/blob/d66c9670b625d5e7ef00f9dddef0a6629a02ca72/client/grpc_query_test.go#L69). As a result, I added a [function](https://github.com/osmosis-labs/cosmos-sdk/blob/6fd8642d68a213d5e2787d2da6ef1363658440be/client/grpc_query.go#L125) to choose the right height (the priority is described in the spec) and correctly pass it to either [GRPC](https://github.com/osmosis-labs/cosmos-sdk/blob/6fd8642d68a213d5e2787d2da6ef1363658440be/client/grpc_query.go#L68-L71) or [ABCI](https://github.com/osmosis-labs/cosmos-sdk/blob/6fd8642d68a213d5e2787d2da6ef1363658440be/client/grpc_query.go#L83) query.

Also, I realized that a number of queries must never be concurrent with ABCI. Specifically, tendermint and simulation. Therefore, those are now always [directed to the ABCI flow](https://github.com/osmosis-labs/cosmos-sdk/blob/6fd8642d68a213d5e2787d2da6ef1363658440be/client/grpc_query.go#L57-L60) to avoid data races. This change should directly address the reported problem in https://github.com/osmosis-labs/osmosis/issues/1356

I proceeded by writing [table-driven tests](https://github.com/osmosis-labs/cosmos-sdk/blob/7caa9cd997ee8811d20c63a51f6914fb8282dc8d/client/grpc_query_test.go#L69) for `TestGRPCQuery` in client and discovered that if a user request a height that does not exist, an error is returned. This is stemming from the fact that IAVL tree never returns an error from `GetImmutable(< height >)` when a non-existent height is requested. Instead it returns an empty tree with nil. This is contrary to what is stated in the following [comment](https://github.com/osmosis-labs/cosmos-sdk/blob/ffbc01a77c0c8751271bd25a3660b895ec4781f4/store/rootmulti/store.go#L476-L481). This problem should be investigated further in a separate issue and potentially fixed. For now, I added an additional safeguard against non-existent heights [here](https://github.com/osmosis-labs/cosmos-sdk/blob/3a6d01a8b4b37fb8c789a260ff31c0edc36641e4/baseapp/abci.go#L606)



## Task Log
- enable GRPC client in integration tests
- fix simulation and Tendermint GRPC queries by directing it to the ABCI flow
- correctly pass height metadata to fix a number of other GRPC query tests
- add unit tests for the new `selectHeight` method
- improve TestGRPCQuery integration tests with table-driven tests
- fix querying non-existent heights.