### PR TITLE
refactor: snapshot manager is created independently from snapshot-int…

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -680,13 +680,13 @@ func (app *BaseApp) GetBlockRetentionHeight(commitHeight int64) int64 {
 		retentionHeight = commitHeight - cp.Evidence.MaxAgeNumBlocks
 	}
 
-	if app.snapshotManager != nil {
+	snapshotInterval := int64(app.snapshotManager.GetInterval())
+	if app.snapshotManager != nil && snapshotInterval > 0 {
 		// Define the state pruning offset, i.e. the block offset at which the
 		// underlying logical database is persisted to disk.
-		statePruningOffset := int64(app.snapshotManager.GetInterval())
-		if statePruningOffset > 0 {
-			if commitHeight > statePruningOffset {
-				v := commitHeight - (commitHeight % statePruningOffset)
+		if snapshotInterval > 0 {
+			if commitHeight > snapshotInterval {
+				v := commitHeight - (commitHeight % snapshotInterval)
 				retentionHeight = minNonZero(retentionHeight, v)
 			} else {
 				// Hitting this case means we have persisting enabled but have yet to reach

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -680,8 +680,8 @@ func (app *BaseApp) GetBlockRetentionHeight(commitHeight int64) int64 {
 		retentionHeight = commitHeight - cp.Evidence.MaxAgeNumBlocks
 	}
 
-	snapshotInterval := int64(app.snapshotManager.GetInterval())
-	if app.snapshotManager != nil && snapshotInterval > 0 {
+	if app.snapshotManager != nil {
+		snapshotInterval := int64(app.snapshotManager.GetInterval())
 		// Define the state pruning offset, i.e. the block offset at which the
 		// underlying logical database is persisted to disk.
 		if snapshotInterval > 0 {
@@ -695,11 +695,10 @@ func (app *BaseApp) GetBlockRetentionHeight(commitHeight int64) int64 {
 				// any state committed to disk.
 				return 0
 			}
-		}
-
-		snapshotRetentionHeights := app.snapshotManager.GetSnapshotBlockRetentionHeights()
-		if snapshotRetentionHeights > 0 {
-			retentionHeight = minNonZero(retentionHeight, commitHeight-snapshotRetentionHeights)
+			snapshotRetentionHeights := app.snapshotManager.GetSnapshotBlockRetentionHeights()
+			if snapshotRetentionHeights > 0 {
+				retentionHeight = minNonZero(retentionHeight, commitHeight-snapshotRetentionHeights)
+			}
 		}
 	}
 

--- a/baseapp/options.go
+++ b/baseapp/options.go
@@ -205,7 +205,7 @@ func (app *BaseApp) SetSnapshot(snapshotStore *snapshots.Store, opts snapshottyp
 	if app.sealed {
 		panic("SetSnapshot() on sealed BaseApp")
 	}
-	if snapshotStore == nil || opts.Interval == snapshottypes.SnapshotIntervalOff {
+	if snapshotStore == nil {
 		app.snapshotManager = nil
 		return
 	}


### PR DESCRIPTION

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #235

## What is the purpose of the change

Earlier snapshot refactor made state-sync work only when `snapshot-interval` is > 0. State-sync should be enabled even when a `snapshot-interval` is 0. This PR makes it so.

## Testing and Verifying

This change is already covered by existing tests, such as *(please describe tests)*.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? yes
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable
