### PR TITLE
refactor: expose SetAppVersion on the upgrade keeper

### DIFF
--- a/x/upgrade/keeper/keeper.go
+++ b/x/upgrade/keeper/keeper.go
@@ -83,6 +83,11 @@ func (k Keeper) SetModuleVersionMap(ctx sdk.Context, vm module.VersionMap) {
 	}
 }
 
+// SetAppVersion sets app version to version
+func (k Keeper) SetAppVersion(ctx sdk.Context, version uint64) error {
+	return k.versionManager.SetAppVersion(ctx, version)
+}
+
 // GetModuleVersionMap returns a map of key module name and value module consensus version
 // as defined in ADR-041.
 func (k Keeper) GetModuleVersionMap(ctx sdk.Context) module.VersionMap {

--- a/x/upgrade/keeper/util_test.go
+++ b/x/upgrade/keeper/util_test.go
@@ -1,8 +1,0 @@
-package keeper
-
-import sdk "github.com/cosmos/cosmos-sdk/types"
-
-// SetAppVersion sets the app version to version. Used for testing the upgrade keeper.
-func (k *Keeper) SetAppVersion(ctx sdk.Context, version uint64) error {
-	return k.versionManager.SetAppVersion(ctx, version)
-}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

exposes `SetAppVersion()` on the upgrade keeper so that we can overwrite it to a higher number during upgrade





## Testing and Verifying

This change is already covered by existing tests

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable
