### PR TITLE
increase maxApproxRootIterations to 300

### DIFF
--- a/types/decimal.go
+++ b/types/decimal.go
@@ -29,7 +29,7 @@ const (
 	maxDecBitLen = maxBitLen + DecimalPrecisionBits
 
 	// max number of iterations in ApproxRoot function
-	maxApproxRootIterations = 100
+	maxApproxRootIterations = 300
 )
 
 var (


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change
 Increase the number of iterations in `ApproxRoot` so that it returns correct value for large `sdk.Dec` input

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes?  no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`?  no
  - How is the feature or change documented?  not documented
