### PR TITLE
refactor: remove 0 initial height assumption in SigVerificationDecorator

### DIFF
--- a/x/auth/ante/expected_keepers.go
+++ b/x/auth/ante/expected_keepers.go
@@ -18,3 +18,7 @@ type AccountKeeper interface {
 type FeegrantKeeper interface {
 	UseGrantedFees(ctx sdk.Context, granter, grantee sdk.AccAddress, fee sdk.Coins, msgs []sdk.Msg) error
 }
+
+type StakingKeeper interface {
+	GetLastTotalPower(ctx sdk.Context) sdk.Int
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

The `SigVerificationDecorator` AnteHandler decorator has a special case for genesis where we need to process GenTx transactions. Naturally, the account numbers when generating GenTxs are all zero, so hence we need this check. However, it's not always the case that a chain might want to have it's initial genesis height be zero.

Note, this is just a potential solution. Perhaps this is not the ideal approach and should be scrapped all together.
