### PR TITLE
feat!: bring back the cliff vesting command (#111)

### DIFF
--- a/x/auth/vesting/client/cli/tx.go
+++ b/x/auth/vesting/client/cli/tx.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
 )
 
@@ -292,7 +293,7 @@ set by the committed block's time. The cliff duration should be specified in hou
 
 			cliffDuration, err := time.ParseDuration(args[2])
 			if err != nil {
-				fmt.Println("duration incorrectly formatted, see https://pkg.go.dev/time#ParseDuration")
+				err = errors.Wrap(err, "duration incorrectly formatted, see https://pkg.go.dev/time#ParseDuration")
 				return err
 			}
 			cliffVesting := true

--- a/x/auth/vesting/client/cli/tx.go
+++ b/x/auth/vesting/client/cli/tx.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"strconv"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -36,6 +37,7 @@ func GetTxCmd() *cobra.Command {
 
 	txCmd.AddCommand(
 		NewMsgCreateVestingAccountCmd(),
+		NewMsgCreateCliffVestingAccountCmd(),
 		NewMsgCreateClawbackVestingAccountCmd(),
 		NewMsgClawbackCmd(),
 	)
@@ -259,5 +261,52 @@ func NewMsgClawbackCmd() *cobra.Command {
 
 	cmd.Flags().String(FlagDest, "", "Address of destination (defaults to funder)")
 	flags.AddTxFlagsToCmd(cmd)
+	return cmd
+}
+
+// NewMsgCreateDelayedVestingAccountCmd returns a CLI command handler for creating a
+// NewMsgCreateDelayedVestingAccountCmd transaction.
+// This is hacky, but meant to mitigate the pain of a very specific use case.
+// Namely, make it easy to make cliff locks to an address.
+func NewMsgCreateCliffVestingAccountCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create-cliff-vesting-account [to_address] [amount] [cliff_duration]",
+		Short: "Create a new cliff vesting account funded with an allocation of tokens.",
+		Long: `Create a new delayed vesting account funded with an allocation of tokens. All vesting accouts created will have their start time
+set by the committed block's time. The cliff duration should be specified in hours.`,
+		Args: cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+			toAddr, err := sdk.AccAddressFromBech32(args[0])
+			if err != nil {
+				return err
+			}
+
+			amount, err := sdk.ParseCoinsNormalized(args[1])
+			if err != nil {
+				return err
+			}
+
+			cliffDuration, err := time.ParseDuration(args[2])
+			if err != nil {
+				fmt.Println("duration incorrectly formatted, see https://pkg.go.dev/time#ParseDuration")
+				return err
+			}
+			cliffVesting := true
+
+			endTime := time.Now().Add(cliffDuration)
+			endEpochTime := endTime.Unix()
+
+			msg := types.NewMsgCreateVestingAccount(clientCtx.GetFromAddress(), toAddr, amount, endEpochTime, cliffVesting)
+
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
+
 	return cmd
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Bring back cliff vesting command from PR #111 , this was a very useful UX flow for folks doing cliff vesting on-chain. 

## Brief Changelog

- Restore the CliffVesting CLI command

## Testing and Verifying

This change is identical to what we had before. 

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? yes
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? Code comment
