### PR TITLE
chore: backport label to v0.45.0x-osmo-v9 and v0.45.0x-osmo-v11

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -61,3 +61,12 @@ pull_request_rules:
       backport:
         branches:
           - v0.45.0x-osmo-v8
+
+  - name: backport patches to v0.45.0x-osmo-v9 branch
+    conditions:
+      - base=osmosis-main
+      - label=A:backport/v0.45.0x-osmo-v9
+    actions:
+      backport:
+        branches:
+          - v0.45.0x-osmo-v9

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -70,3 +70,11 @@ pull_request_rules:
       backport:
         branches:
           - v0.45.0x-osmo-v9
+  - name: backport patches to v0.45.0x-osmo-v11 branch
+    conditions:
+      - base=osmosis-main
+      - label=A:backport/v0.45.0x-osmo-v11
+    actions:
+      backport:
+        branches:
+          - v0.45.0x-osmo-v11


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

backport label for `v0.45.0x-osmo-v9` and `v0.45.0x-osmo-v11`

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable
