### PR TITLE
fix: rest query total supply of

### DIFF
--- a/x/bank/keeper/querier.go
+++ b/x/bank/keeper/querier.go
@@ -110,6 +110,7 @@ func querySupplyOf(ctx sdk.Context, req abci.RequestQuery, k Keeper, legacyQueri
 	}
 
 	amount := k.GetSupply(ctx, params.Denom)
+	amount.Amount = amount.Amount.Add(k.GetSupplyOffset(ctx, params.Denom))
 	supply := sdk.NewCoin(params.Denom, amount.Amount)
 
 	bz, err := codec.MarshalJSONIndent(legacyQuerierCdc, supply)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: https://github.com/osmosis-labs/osmosis/issues/1882

## What is the purpose of the change

Rest query for total supply is wrong because it doesn't count supply offset, so I change `querySupplyOf` function used by the rest querier

## Brief Changelog

Add this line to `querySupplyOf` :
`amount.Amount = amount.Amount.Add(k.GetSupplyOffset(ctx, params.Denom))`

## Testing and Verifying

This change is already covered by existing tests, such as *(please describe tests)*.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not documented
