### PR TITLE
feat: concurrency query client option (backport)

### DIFF
--- a/client/cmd.go
+++ b/client/cmd.go
@@ -103,7 +103,7 @@ func ReadPersistentCommandFlags(clientCtx Context, flagSet *pflag.FlagSet) (Cont
 		clientCtx = clientCtx.WithSimulation(dryRun)
 	}
 
-	if !clientCtx.Concurrency || flagSet.Changed(flags.FlagConcurrency) {
+	if !clientCtx.GRPCConcurrency || flagSet.Changed(flags.FlagConcurrency) {
 		concurrency, _ := flagSet.GetBool(flags.FlagConcurrency)
 		clientCtx = clientCtx.WithConcurrency(concurrency)
 	}

--- a/client/cmd.go
+++ b/client/cmd.go
@@ -103,6 +103,11 @@ func ReadPersistentCommandFlags(clientCtx Context, flagSet *pflag.FlagSet) (Cont
 		clientCtx = clientCtx.WithSimulation(dryRun)
 	}
 
+	if !clientCtx.Concurrency || flagSet.Changed(flags.FlagConcurrency) {
+		concurrency, _ := flagSet.GetBool(flags.FlagConcurrency)
+		clientCtx = clientCtx.WithConcurrency(concurrency)
+	}
+
 	if clientCtx.KeyringDir == "" || flagSet.Changed(flags.FlagKeyringDir) {
 		keyringDir, _ := flagSet.GetString(flags.FlagKeyringDir)
 

--- a/client/cmd.go
+++ b/client/cmd.go
@@ -103,9 +103,9 @@ func ReadPersistentCommandFlags(clientCtx Context, flagSet *pflag.FlagSet) (Cont
 		clientCtx = clientCtx.WithSimulation(dryRun)
 	}
 
-	if !clientCtx.GRPCConcurrency || flagSet.Changed(flags.FlagConcurrency) {
-		concurrency, _ := flagSet.GetBool(flags.FlagConcurrency)
-		clientCtx = clientCtx.WithConcurrency(concurrency)
+	if !clientCtx.GRPCConcurrency || flagSet.Changed(flags.FlagGRPCConcurrency) {
+		grpcConcurrency, _ := flagSet.GetBool(flags.FlagGRPCConcurrency)
+		clientCtx = clientCtx.WithConcurrency(grpcConcurrency)
 	}
 
 	if clientCtx.KeyringDir == "" || flagSet.Changed(flags.FlagKeyringDir) {

--- a/client/config/cmd.go
+++ b/client/config/cmd.go
@@ -58,6 +58,8 @@ func runConfigCmd(cmd *cobra.Command, args []string) error {
 			cmd.Println(conf.Node)
 		case flags.FlagBroadcastMode:
 			cmd.Println(conf.BroadcastMode)
+		case flags.FlagConcurrency:
+			cmd.Println(conf.Concurrency)
 		default:
 			err := errUnknownConfigKey(key)
 			return fmt.Errorf("couldn't get the value for the key: %v, error:  %v", key, err)
@@ -78,6 +80,8 @@ func runConfigCmd(cmd *cobra.Command, args []string) error {
 			conf.SetNode(value)
 		case flags.FlagBroadcastMode:
 			conf.SetBroadcastMode(value)
+		case flags.FlagConcurrency:
+			cmd.Println(conf.Concurrency)
 		default:
 			return errUnknownConfigKey(key)
 		}

--- a/client/config/cmd.go
+++ b/client/config/cmd.go
@@ -58,7 +58,7 @@ func runConfigCmd(cmd *cobra.Command, args []string) error {
 			cmd.Println(conf.Node)
 		case flags.FlagBroadcastMode:
 			cmd.Println(conf.BroadcastMode)
-		case flags.FlagConcurrency:
+		case flags.FlagGRPCConcurrency:
 			cmd.Println(conf.GRPCConcurrency)
 		default:
 			err := errUnknownConfigKey(key)
@@ -80,7 +80,7 @@ func runConfigCmd(cmd *cobra.Command, args []string) error {
 			conf.SetNode(value)
 		case flags.FlagBroadcastMode:
 			conf.SetBroadcastMode(value)
-		case flags.FlagConcurrency:
+		case flags.FlagGRPCConcurrency:
 			cmd.Println(conf.GRPCConcurrency)
 		default:
 			return errUnknownConfigKey(key)

--- a/client/config/cmd.go
+++ b/client/config/cmd.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"strconv"
 
 	tmcli "github.com/tendermint/tendermint/libs/cli"
 
@@ -81,7 +82,8 @@ func runConfigCmd(cmd *cobra.Command, args []string) error {
 		case flags.FlagBroadcastMode:
 			conf.SetBroadcastMode(value)
 		case flags.FlagGRPCConcurrency:
-			cmd.Println(conf.GRPCConcurrency)
+			valuebool, _ := strconv.ParseBool(value)
+			conf.SetGRPCConcurrency(valuebool)
 		default:
 			return errUnknownConfigKey(key)
 		}

--- a/client/config/cmd.go
+++ b/client/config/cmd.go
@@ -59,7 +59,7 @@ func runConfigCmd(cmd *cobra.Command, args []string) error {
 		case flags.FlagBroadcastMode:
 			cmd.Println(conf.BroadcastMode)
 		case flags.FlagConcurrency:
-			cmd.Println(conf.Concurrency)
+			cmd.Println(conf.GRPCConcurrency)
 		default:
 			err := errUnknownConfigKey(key)
 			return fmt.Errorf("couldn't get the value for the key: %v, error:  %v", key, err)
@@ -81,7 +81,7 @@ func runConfigCmd(cmd *cobra.Command, args []string) error {
 		case flags.FlagBroadcastMode:
 			conf.SetBroadcastMode(value)
 		case flags.FlagConcurrency:
-			cmd.Println(conf.Concurrency)
+			cmd.Println(conf.GRPCConcurrency)
 		default:
 			return errUnknownConfigKey(key)
 		}

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -52,7 +52,7 @@ func (c *ClientConfig) SetBroadcastMode(broadcastMode string) {
 	c.BroadcastMode = broadcastMode
 }
 
-func (c *ClientConfig) SetConcurrency(grpConcurrency bool) {
+func (c *ClientConfig) SetGRPCConcurrency(grpConcurrency bool) {
 	c.GRPCConcurrency = grpcConcurrency
 }
 

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -10,26 +10,26 @@ import (
 
 // Default constants
 const (
-	chainID        = ""
-	keyringBackend = "os"
-	output         = "text"
-	node           = "tcp://localhost:26657"
-	broadcastMode  = "sync"
-	concurrency    = false
+	chainID         = ""
+	keyringBackend  = "os"
+	output          = "text"
+	node            = "tcp://localhost:26657"
+	broadcastMode   = "sync"
+	grpcConcurrency = false
 )
 
 type ClientConfig struct {
-	ChainID        string `mapstructure:"chain-id" json:"chain-id"`
-	KeyringBackend string `mapstructure:"keyring-backend" json:"keyring-backend"`
-	Output         string `mapstructure:"output" json:"output"`
-	Node           string `mapstructure:"node" json:"node"`
-	BroadcastMode  string `mapstructure:"broadcast-mode" json:"broadcast-mode"`
-	Concurrency    bool   `mapstructure:"concurrency" json:"concurrency"`
+	ChainID         string `mapstructure:"chain-id" json:"chain-id"`
+	KeyringBackend  string `mapstructure:"keyring-backend" json:"keyring-backend"`
+	Output          string `mapstructure:"output" json:"output"`
+	Node            string `mapstructure:"node" json:"node"`
+	BroadcastMode   string `mapstructure:"broadcast-mode" json:"broadcast-mode"`
+	GRPCConcurrency bool   `mapstructure:"grpc-concurrency" json:"grpc-concurrency"`
 }
 
 // defaultClientConfig returns the reference to ClientConfig with default values.
 func defaultClientConfig() *ClientConfig {
-	return &ClientConfig{chainID, keyringBackend, output, node, broadcastMode, concurrency}
+	return &ClientConfig{chainID, keyringBackend, output, node, broadcastMode, grpcConcurrency}
 }
 
 func (c *ClientConfig) SetChainID(chainID string) {
@@ -52,8 +52,8 @@ func (c *ClientConfig) SetBroadcastMode(broadcastMode string) {
 	c.BroadcastMode = broadcastMode
 }
 
-func (c *ClientConfig) SetConcurrency(concurrency bool) {
-	c.Concurrency = concurrency
+func (c *ClientConfig) SetConcurrency(grpConcurrency bool) {
+	c.GRPCConcurrency = grpcConcurrency
 }
 
 // ReadFromClientConfig reads values from client.toml file and updates them in client Context

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -15,6 +15,7 @@ const (
 	output         = "text"
 	node           = "tcp://localhost:26657"
 	broadcastMode  = "sync"
+	concurrency    = false
 )
 
 type ClientConfig struct {
@@ -23,11 +24,12 @@ type ClientConfig struct {
 	Output         string `mapstructure:"output" json:"output"`
 	Node           string `mapstructure:"node" json:"node"`
 	BroadcastMode  string `mapstructure:"broadcast-mode" json:"broadcast-mode"`
+	Concurrency    bool   `mapstructure:"concurrency" json:"concurrency"`
 }
 
 // defaultClientConfig returns the reference to ClientConfig with default values.
 func defaultClientConfig() *ClientConfig {
-	return &ClientConfig{chainID, keyringBackend, output, node, broadcastMode}
+	return &ClientConfig{chainID, keyringBackend, output, node, broadcastMode, concurrency}
 }
 
 func (c *ClientConfig) SetChainID(chainID string) {
@@ -48,6 +50,10 @@ func (c *ClientConfig) SetNode(node string) {
 
 func (c *ClientConfig) SetBroadcastMode(broadcastMode string) {
 	c.BroadcastMode = broadcastMode
+}
+
+func (c *ClientConfig) SetConcurrency(concurrency bool) {
+	c.Concurrency = concurrency
 }
 
 // ReadFromClientConfig reads values from client.toml file and updates them in client Context

--- a/client/config/toml.go
+++ b/client/config/toml.go
@@ -26,6 +26,10 @@ output = "{{ .Output }}"
 node = "{{ .Node }}"
 # Transaction broadcasting mode (sync|async|block)
 broadcast-mode = "{{ .BroadcastMode }}"
+# Concurrency defines if node queries should be done in parallel.
+# This is experimental and has led to node failures, so enable with caution.
+# The default value is false.
+concurrency = {{ .Concurrency }}
 `
 
 // writeConfigToFile parses defaultConfigTemplate, renders config using the template and writes it to

--- a/client/config/toml.go
+++ b/client/config/toml.go
@@ -13,7 +13,7 @@ const defaultConfigTemplate = `# This is a TOML config file.
 # For more information, see https://github.com/toml-lang/toml
 
 ###############################################################################
-###                           Client Configuration                            ###
+###                           Client Configuration                          ###
 ###############################################################################
 
 # The network chain ID

--- a/client/config/toml.go
+++ b/client/config/toml.go
@@ -29,7 +29,7 @@ broadcast-mode = "{{ .BroadcastMode }}"
 # Concurrency defines if node queries should be done in parallel.
 # This is experimental and has led to node failures, so enable with caution.
 # The default value is false.
-concurrency = {{ .Concurrency }}
+grpc-concurrency = {{ .GRPCConcurrency }}
 `
 
 // writeConfigToFile parses defaultConfigTemplate, renders config using the template and writes it to

--- a/client/context.go
+++ b/client/context.go
@@ -43,7 +43,7 @@ type Context struct {
 	KeyringDir        string
 	From              string
 	BroadcastMode     string
-	Concurrency       bool
+	GRPCConcurrency   bool
 	FromName          string
 	SignModeStr       string
 	UseLedger         bool
@@ -254,8 +254,8 @@ func (ctx Context) WithInterfaceRegistry(interfaceRegistry codectypes.InterfaceR
 	return ctx
 }
 
-func (ctx Context) WithConcurrency(concurrency bool) Context {
-	ctx.Concurrency = concurrency
+func (ctx Context) WithConcurrency(grpcConcurrency bool) Context {
+	ctx.GRPCConcurrency = grpcConcurrency
 	return ctx
 }
 

--- a/client/context.go
+++ b/client/context.go
@@ -43,6 +43,7 @@ type Context struct {
 	KeyringDir        string
 	From              string
 	BroadcastMode     string
+	Concurrency       bool
 	FromName          string
 	SignModeStr       string
 	UseLedger         bool

--- a/client/context.go
+++ b/client/context.go
@@ -254,6 +254,11 @@ func (ctx Context) WithInterfaceRegistry(interfaceRegistry codectypes.InterfaceR
 	return ctx
 }
 
+func (ctx Context) WithConcurrency(concurrency bool) Context {
+	ctx.Concurrency = concurrency
+	return ctx
+}
+
 // WithViper returns the context with Viper field. This Viper instance is used to read
 // client-side config from the config file.
 func (ctx Context) WithViper(prefix string) Context {

--- a/client/flags/flags.go
+++ b/client/flags/flags.go
@@ -72,7 +72,7 @@ const (
 	FlagKeyAlgorithm     = "algo"
 	FlagFeeAccount       = "fee-account"
 	FlagReverse          = "reverse"
-	FlagConcurrency      = "concurrency"
+	FlagGRPCConcurrency  = "grpc-concurrency"
 
 	// Tendermint logging flags
 	FlagLogLevel  = "log_level"

--- a/client/flags/flags.go
+++ b/client/flags/flags.go
@@ -72,6 +72,7 @@ const (
 	FlagKeyAlgorithm     = "algo"
 	FlagFeeAccount       = "fee-account"
 	FlagReverse          = "reverse"
+	FlagConcurrency      = "concurrency"
 
 	// Tendermint logging flags
 	FlagLogLevel  = "log_level"

--- a/client/grpc_query.go
+++ b/client/grpc_query.go
@@ -57,7 +57,7 @@ func (ctx Context) Invoke(grpcCtx gocontext.Context, method string, req, reply i
 	_, isSimulationRequest := req.(*tx.SimulateRequest)
 	isTendermintQuery := strings.Contains(method, "tendermint")
 	grpcConcurrentEnabled := ctx.GRPCConcurrency
-	isGRPCAllowed := !isTendermintQuery && !isSimulationRequest && grpcConcurrentEnabled
+	isGRPCAllowed := !isTendermintQuery && !isSimulationRequest && !grpcConcurrentEnabled
 
 	requestedHeight, err := selectHeight(ctx, grpcCtx)
 	if err != nil {

--- a/client/grpc_query.go
+++ b/client/grpc_query.go
@@ -56,8 +56,8 @@ func (ctx Context) Invoke(grpcCtx gocontext.Context, method string, req, reply i
 	// As a result, we direct them to the ABCI flow where they get syncronized.
 	_, isSimulationRequest := req.(*tx.SimulateRequest)
 	isTendermintQuery := strings.Contains(method, "tendermint")
-	isConcurrentQuery := ctx.Concurrency
-	isGRPCAllowed := !isTendermintQuery && !isSimulationRequest && !isConcurrentQuery
+	grpcConcurrentEnabled := ctx.Concurrency
+	isGRPCAllowed := !isTendermintQuery && !isSimulationRequest && isConcurrentQuery
 
 	requestedHeight, err := selectHeight(ctx, grpcCtx)
 	if err != nil {

--- a/client/grpc_query.go
+++ b/client/grpc_query.go
@@ -56,8 +56,8 @@ func (ctx Context) Invoke(grpcCtx gocontext.Context, method string, req, reply i
 	// As a result, we direct them to the ABCI flow where they get syncronized.
 	_, isSimulationRequest := req.(*tx.SimulateRequest)
 	isTendermintQuery := strings.Contains(method, "tendermint")
-
-	isGRPCAllowed := !isTendermintQuery && !isSimulationRequest
+	isConcurrentQuery := ctx.Concurrency
+	isGRPCAllowed := !isTendermintQuery && !isSimulationRequest && !isConcurrentQuery
 
 	requestedHeight, err := selectHeight(ctx, grpcCtx)
 	if err != nil {

--- a/client/grpc_query.go
+++ b/client/grpc_query.go
@@ -57,7 +57,7 @@ func (ctx Context) Invoke(grpcCtx gocontext.Context, method string, req, reply i
 	_, isSimulationRequest := req.(*tx.SimulateRequest)
 	isTendermintQuery := strings.Contains(method, "tendermint")
 	grpcConcurrentEnabled := ctx.GRPCConcurrency
-	isGRPCAllowed := !isTendermintQuery && !isSimulationRequest && !grpcConcurrentEnabled
+	isGRPCAllowed := !isTendermintQuery && !isSimulationRequest && grpcConcurrentEnabled
 
 	requestedHeight, err := selectHeight(ctx, grpcCtx)
 	if err != nil {

--- a/client/grpc_query.go
+++ b/client/grpc_query.go
@@ -56,8 +56,8 @@ func (ctx Context) Invoke(grpcCtx gocontext.Context, method string, req, reply i
 	// As a result, we direct them to the ABCI flow where they get syncronized.
 	_, isSimulationRequest := req.(*tx.SimulateRequest)
 	isTendermintQuery := strings.Contains(method, "tendermint")
-	grpcConcurrentEnabled := ctx.Concurrency
-	isGRPCAllowed := !isTendermintQuery && !isSimulationRequest && isConcurrentQuery
+	grpcConcurrentEnabled := ctx.GRPCConcurrency
+	isGRPCAllowed := !isTendermintQuery && !isSimulationRequest && grpcConcurrentEnabled
 
 	requestedHeight, err := selectHeight(ctx, grpcCtx)
 	if err != nil {

--- a/client/grpc_query_test.go
+++ b/client/grpc_query_test.go
@@ -66,6 +66,22 @@ func (s *IntegrationTestSuite) TestGRPCQuery_TestService() {
 	s.Require().Equal("hello", testRes.Message)
 }
 
+func (s *IntegrationTestSuite) TestGRPCConcurrency() {
+	val0 := s.network.Validators[0]
+	clientCtx := val0.ClientCtx
+	clientCtx.GRPCConcurrency = true
+	in := &testdata.EchoRequest{Message: "hello"}
+	out := &testdata.EchoResponse{}
+	err := clientCtx.Invoke(context.Background(), "/testdata.Query/Echo", in, out)
+	s.Require().NoError(err)
+	s.Require().Equal("hello", out.Message)
+
+	clientCtx.GRPCConcurrency = false
+	err = clientCtx.Invoke(context.Background(), "/testdata.Query/Echo", in, out)
+	s.Require().NoError(err)
+	s.Require().Equal("hello", out.Message)
+}
+
 func (s *IntegrationTestSuite) TestGRPCQuery_BankService_VariousInputs() {
 	val0 := s.network.Validators[0]
 

--- a/client/grpc_query_test.go
+++ b/client/grpc_query_test.go
@@ -175,6 +175,7 @@ func TestSelectHeight(t *testing.T) {
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
 			clientCtx := client.Context{}
+			clientCtx.GRPCConcurrency = true
 			if tc.clientContextHeight != heightNotSetFlag {
 				clientCtx = clientCtx.WithHeight(tc.clientContextHeight)
 			}

--- a/client/grpc_query_test.go
+++ b/client/grpc_query_test.go
@@ -108,6 +108,7 @@ func (s *IntegrationTestSuite) TestGRPCQuery_BankService_VariousInputs() {
 		s.T().Run(name, func(t *testing.T) {
 			// Setup
 			clientCtx := val0.ClientCtx
+			clientCtx.GRPCConcurrency = true
 			clientCtx.Height = 0
 
 			if tc.clientContextHeight != heightNotSetFlag {

--- a/x/auth/tx/service_test.go
+++ b/x/auth/tx/service_test.go
@@ -442,6 +442,7 @@ func (s IntegrationTestSuite) TestBroadcastTx_GRPC() {
 
 func (s IntegrationTestSuite) TestBroadcastTx_GRPCGateway() {
 	val := s.network.Validators[0]
+	val.ClientCtx.GRPCConcurrency = true
 	txBuilder := s.mkTxBuilder()
 	txBytes, err := val.ClientCtx.TxConfig.TxEncoder()(txBuilder.GetTx())
 	s.Require().NoError(err)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: [#1561](https://github.com/osmosis-labs/osmosis/issues/1651)

## What is the purpose of the change

This pull request adds an additional option to the client.toml file called "concurrency" which defaults to false. When set to true, this allows certain queries to be done in parallel via gRPC.


## Brief Changelog

- add concurrency option in client.toml
- add respective flags


## Testing and Verifying

This change is already covered by existing tests


## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? not yet
  - How is the feature or change documented? not applicable
