### PR TITLE
chore: implement redacted fix

### DIFF
--- a/types/errors/abci.go
+++ b/types/errors/abci.go
@@ -109,16 +109,16 @@ func debugErrEncoder(err error) string {
 	return fmt.Sprintf("%+v", err)
 }
 
-// The defaultErrEncoder applies Redact on the error before encoding it with its internal error message.
+// The defaultErrEncoder encodes the error with its internal error message.
 func defaultErrEncoder(err error) string {
-	return Redact(err).Error()
+	return err.Error()
 }
 
 type coder interface {
 	ABCICode() uint32
 }
 
-// abciCode test if given error contains an ABCI code and returns the value of
+// abciCode tests if given error contains an ABCI code and returns the value of
 // it if available. This function is testing for the causer interface as well
 // and unwraps the error.
 func abciCode(err error) uint32 {
@@ -177,20 +177,4 @@ func errIsNil(err error) bool {
 		return val.IsNil()
 	}
 	return false
-}
-
-var errPanicWithMsg = Wrapf(ErrPanic, "panic message redacted to hide potentially sensitive system info")
-
-// Redact replaces an error that is not initialized as an ABCI Error with a
-// generic internal error instance. If the error is an ABCI Error, that error is
-// simply returned.
-func Redact(err error) error {
-	if ErrPanic.Is(err) {
-		return errPanicWithMsg
-	}
-	if abciCode(err) == internalABCICode {
-		return errInternal
-	}
-
-	return err
 }


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Implements https://github.com/cosmos/cosmos-sdk/pull/12002 from upstream to our fork

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [x] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [x] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [x] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
