### PR TITLE
fix!: Don't allow supplyWithOffset to go negative

### DIFF
--- a/x/bank/keeper/keeper.go
+++ b/x/bank/keeper/keeper.go
@@ -31,7 +31,7 @@ type Keeper interface {
 	GetPaginatedTotalSupply(ctx sdk.Context, pagination *query.PageRequest) (sdk.Coins, *query.PageResponse, error)
 	IterateTotalSupply(ctx sdk.Context, cb func(sdk.Coin) bool)
 	GetSupplyOffset(ctx sdk.Context, denom string) sdk.Int
-	AddSupplyOffset(ctx sdk.Context, denom string, offsetAmount sdk.Int)
+	AddSupplyOffset(ctx sdk.Context, denom string, offsetAmount sdk.Int) error
 	GetSupplyWithOffset(ctx sdk.Context, denom string) sdk.Coin
 	GetPaginatedTotalSupplyWithOffsets(ctx sdk.Context, pagination *query.PageRequest) (sdk.Coins, *query.PageResponse, error)
 	IterateTotalSupplyWithOffsets(ctx sdk.Context, cb func(sdk.Coin) bool)

--- a/x/bank/keeper/supply_offset_test.go
+++ b/x/bank/keeper/supply_offset_test.go
@@ -1,0 +1,54 @@
+package keeper_test
+
+import (
+	gocontext "context"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/bank/types"
+	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
+)
+
+func (suite *IntegrationTestSuite) TestAddSupplyOffset() {
+	app, ctx, queryClient := suite.app, suite.ctx, suite.queryClient
+
+	test1Supply := sdk.NewInt64Coin("test1", 4000000)
+	expectedTotalSupply := sdk.NewCoins(test1Supply)
+	suite.
+		Require().
+		NoError(app.BankKeeper.MintCoins(ctx, minttypes.ModuleName, expectedTotalSupply))
+
+	_, err := queryClient.SupplyOf(gocontext.Background(), &types.QuerySupplyOfRequest{})
+	suite.Require().Error(err)
+
+	res, err := queryClient.SupplyOf(gocontext.Background(), &types.QuerySupplyOfRequest{Denom: test1Supply.Denom})
+	suite.Require().NoError(err)
+	suite.Require().NotNil(res)
+
+	suite.Require().Equal(test1Supply, res.Amount)
+
+	// test total supply of query with supply offset
+	err = app.BankKeeper.AddSupplyOffset(ctx, "test1", sdk.NewInt(-1000000))
+	suite.Require().NoError(err)
+	res, err = queryClient.SupplyOf(gocontext.Background(), &types.QuerySupplyOfRequest{Denom: test1Supply.Denom})
+	suite.Require().NoError(err)
+	suite.Require().NotNil(res)
+
+	suite.Require().Equal(test1Supply.Sub(sdk.NewInt64Coin("test1", 1000000)), res.Amount)
+
+	// make sure query without offsets hasn't changed
+	res2, err := queryClient.SupplyOfWithoutOffset(gocontext.Background(), &types.QuerySupplyOfWithoutOffsetRequest{Denom: test1Supply.Denom})
+	suite.Require().NoError(err)
+	suite.Require().NotNil(res2)
+
+	suite.Require().Equal(test1Supply, res2.Amount)
+
+	// make sure that the supplyWithoutOffset can't go negative
+	err = app.BankKeeper.AddSupplyOffset(ctx, "test1", sdk.NewInt(-4000000))
+	suite.Require().Error(err)
+
+	// make sure supply didn't change
+	res2, err = queryClient.SupplyOfWithoutOffset(gocontext.Background(), &types.QuerySupplyOfWithoutOffsetRequest{Denom: test1Supply.Denom})
+	suite.Require().NoError(err)
+	suite.Require().NotNil(res2)
+	suite.Require().Equal(test1Supply, res2.Amount)
+}

--- a/x/bank/keeper/supply_offset_test.go
+++ b/x/bank/keeper/supply_offset_test.go
@@ -9,46 +9,74 @@ import (
 )
 
 func (suite *IntegrationTestSuite) TestAddSupplyOffset() {
-	app, ctx, queryClient := suite.app, suite.ctx, suite.queryClient
 
-	test1Supply := sdk.NewInt64Coin("test1", 4000000)
-	expectedTotalSupply := sdk.NewCoins(test1Supply)
-	suite.
-		Require().
-		NoError(app.BankKeeper.MintCoins(ctx, minttypes.ModuleName, expectedTotalSupply))
+	testCases := []struct {
+		description        string
+		initialSupply      sdk.Int
+		supplyOffsetAmount sdk.Int
+		expPass            bool
+		supplyWithOffset   sdk.Int
+	}{
+		{
+			description:        "test positive supply offset",
+			initialSupply:      sdk.NewInt(10000),
+			supplyOffsetAmount: sdk.NewInt(1000),
+			expPass:            true,
+			supplyWithOffset:   sdk.NewInt(11000),
+		},
+		{
+			description:        "test negative supply offset",
+			initialSupply:      sdk.NewInt(10000),
+			supplyOffsetAmount: sdk.NewInt(-1000),
+			expPass:            true,
+			supplyWithOffset:   sdk.NewInt(9000),
+		},
+		{
+			description:        "make sure that supplyWithOffset can't go negative",
+			initialSupply:      sdk.NewInt(10000),
+			supplyOffsetAmount: sdk.NewInt(-11000),
+			expPass:            false,
+			supplyWithOffset:   sdk.NewInt(10000),
+		},
+	}
 
-	_, err := queryClient.SupplyOf(gocontext.Background(), &types.QuerySupplyOfRequest{})
-	suite.Require().Error(err)
+	for _, tc := range testCases {
+		tc := tc
 
-	res, err := queryClient.SupplyOf(gocontext.Background(), &types.QuerySupplyOfRequest{Denom: test1Supply.Denom})
-	suite.Require().NoError(err)
-	suite.Require().NotNil(res)
+		suite.Run(tc.description, func() {
+			app, ctx, queryClient := suite.app, suite.ctx, suite.queryClient
 
-	suite.Require().Equal(test1Supply, res.Amount)
+			// mint the initialSupply coins
+			test1Supply := sdk.NewCoin("test1", tc.initialSupply)
+			suite.
+				Require().
+				NoError(app.BankKeeper.MintCoins(ctx, minttypes.ModuleName, sdk.NewCoins(test1Supply)))
 
-	// test total supply of query with supply offset
-	err = app.BankKeeper.AddSupplyOffset(ctx, "test1", sdk.NewInt(-1000000))
-	suite.Require().NoError(err)
-	res, err = queryClient.SupplyOf(gocontext.Background(), &types.QuerySupplyOfRequest{Denom: test1Supply.Denom})
-	suite.Require().NoError(err)
-	suite.Require().NotNil(res)
+			// make sure that queried supply is correct
+			res, err := queryClient.SupplyOf(gocontext.Background(), &types.QuerySupplyOfRequest{Denom: test1Supply.Denom})
+			suite.Require().NoError(err)
+			suite.Require().NotNil(res)
+			suite.Require().Equal(test1Supply, res.Amount)
 
-	suite.Require().Equal(test1Supply.Sub(sdk.NewInt64Coin("test1", 1000000)), res.Amount)
+			// try adding the supply offset
+			err = app.BankKeeper.AddSupplyOffset(ctx, "test1", tc.supplyOffsetAmount)
+			if tc.expPass {
+				suite.Require().NoError(err)
+			} else {
+				suite.Require().Error(err)
+			}
 
-	// make sure query without offsets hasn't changed
-	res2, err := queryClient.SupplyOfWithoutOffset(gocontext.Background(), &types.QuerySupplyOfWithoutOffsetRequest{Denom: test1Supply.Denom})
-	suite.Require().NoError(err)
-	suite.Require().NotNil(res2)
+			// test querying supply results in expected change
+			res, err = queryClient.SupplyOf(gocontext.Background(), &types.QuerySupplyOfRequest{Denom: test1Supply.Denom})
+			suite.Require().NoError(err)
+			suite.Require().NotNil(res)
+			suite.Require().Equal(tc.supplyWithOffset, res.Amount.Amount)
 
-	suite.Require().Equal(test1Supply, res2.Amount)
-
-	// make sure that the supplyWithoutOffset can't go negative
-	err = app.BankKeeper.AddSupplyOffset(ctx, "test1", sdk.NewInt(-4000000))
-	suite.Require().Error(err)
-
-	// make sure supply didn't change
-	res2, err = queryClient.SupplyOfWithoutOffset(gocontext.Background(), &types.QuerySupplyOfWithoutOffsetRequest{Denom: test1Supply.Denom})
-	suite.Require().NoError(err)
-	suite.Require().NotNil(res2)
-	suite.Require().Equal(test1Supply, res2.Amount)
+			// test querying supply without offset did not change
+			res2, err := queryClient.SupplyOfWithoutOffset(gocontext.Background(), &types.QuerySupplyOfWithoutOffsetRequest{Denom: test1Supply.Denom})
+			suite.Require().NoError(err)
+			suite.Require().NotNil(res2)
+			suite.Require().Equal(test1Supply, res2.Amount)
+		})
+	}
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

> Add a description of the overall background and high-level changes that this PR introduces

This PR prevents SupplyWithOffset to not go negative.

Not checking this is currently a bug, because in many places, the SupplyWithOffset (an sdk.Int) is cast to an sdk.Coin, which does not allow negative values.

## Brief Changelog

*(for example:)*
 
  - Errors if SupplyOffset is trying to be set that makes Supply - SupplyOffset is negative.


## Testing and Verifying

This change added unit tests.


## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)
