### PR TITLE
fix: check denom of SpendLimit

### DIFF
--- a/simapp/helpers/test_helpers.go
+++ b/simapp/helpers/test_helpers.go
@@ -13,8 +13,10 @@ import (
 )
 
 // SimAppChainID hardcoded chainID for simulation
+// TODO: Implement a tool to check for gas growth. For now,
+// we must increase this across the board for longer runs to work
 const (
-	DefaultGenTxGas = 1000000
+	DefaultGenTxGas = 2000000
 	SimAppChainID   = "simulation-app"
 )
 

--- a/x/authz/simulation/operations.go
+++ b/x/authz/simulation/operations.go
@@ -249,7 +249,7 @@ func SimulateMsgExec(ak authz.AccountKeeper, bk authz.BankKeeper, k keeper.Keepe
 			return simtypes.NoOpMsg(authz.ModuleName, TypeMsgExec, "not a send authorization"), nil, nil
 		}
 
-		if sendAuth.SpendLimit.IsAllLTE(coins) {
+		if sendAuth.SpendLimit.IsAllLTE(coins) && coins.DenomsSubsetOf(sendAuth.SpendLimit) {
 			return simtypes.NoOpMsg(authz.ModuleName, TypeMsgExec, "over spend limit"), nil, nil
 		}
 

--- a/x/authz/simulation/operations.go
+++ b/x/authz/simulation/operations.go
@@ -249,7 +249,7 @@ func SimulateMsgExec(ak authz.AccountKeeper, bk authz.BankKeeper, k keeper.Keepe
 			return simtypes.NoOpMsg(authz.ModuleName, TypeMsgExec, "not a send authorization"), nil, nil
 		}
 
-		if sendAuth.SpendLimit.IsAllLTE(coins) && coins.DenomsSubsetOf(sendAuth.SpendLimit) {
+		if !sendAuth.SpendLimit.IsAllGTE(coins) || !coins.DenomsSubsetOf(sendAuth.SpendLimit) {
 			return simtypes.NoOpMsg(authz.ModuleName, TypeMsgExec, "over spend limit"), nil, nil
 		}
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: https://github.com/osmosis-labs/osmosis/issues/2170

## What is the purpose of the change

This PR fixes a small bug in the Authz simulator code found when running extended simulations.

## Brief Changelog

- Checks that the coins being sent through Authz are a subset of the denoms allotted through the SpendLimit

## Testing and Verifying

This change is already covered by existing tests

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable
