### PR TITLE
feat: negative supplyWithOffset returns 0

### DIFF
--- a/x/bank/keeper/grpc_query_test.go
+++ b/x/bank/keeper/grpc_query_test.go
@@ -157,7 +157,6 @@ func (suite *IntegrationTestSuite) TestQueryTotalSupplyOf() {
 	suite.Require().NotNil(res)
 
 	suite.Require().Equal(sdk.NewInt64Coin("test1", 0), res.Amount)
-
 }
 
 func (suite *IntegrationTestSuite) TestQueryParams() {

--- a/x/bank/keeper/grpc_query_test.go
+++ b/x/bank/keeper/grpc_query_test.go
@@ -149,6 +149,15 @@ func (suite *IntegrationTestSuite) TestQueryTotalSupplyOf() {
 	suite.Require().NotNil(res2)
 
 	suite.Require().Equal(test1Supply, res2.Amount)
+
+	// try to make SupplyWithOffset negative, should return as 0
+	app.BankKeeper.AddSupplyOffset(ctx, "test1", sdk.NewInt(-100000000000))
+	res, err = queryClient.SupplyOf(gocontext.Background(), &types.QuerySupplyOfRequest{Denom: test1Supply.Denom})
+	suite.Require().NoError(err)
+	suite.Require().NotNil(res)
+
+	suite.Require().Equal(sdk.NewInt64Coin("test1", 0), res.Amount)
+
 }
 
 func (suite *IntegrationTestSuite) TestQueryParams() {

--- a/x/bank/keeper/supply_offset.go
+++ b/x/bank/keeper/supply_offset.go
@@ -52,9 +52,16 @@ func (k BaseKeeper) AddSupplyOffset(ctx sdk.Context, denom string, offsetAmount 
 }
 
 // GetSupplyWithOffset retrieves the Supply of a denom and offsets it by SupplyOffset
+// If SupplyWithOffset is negative, it returns 0.  This is because sdk.Coin is not valid
+// with a negative amount
 func (k BaseKeeper) GetSupplyWithOffset(ctx sdk.Context, denom string) sdk.Coin {
 	supply := k.GetSupply(ctx, denom)
 	supply.Amount = supply.Amount.Add(k.GetSupplyOffset(ctx, denom))
+
+	if supply.Amount.IsNegative() {
+		supply.Amount = sdk.ZeroInt()
+	}
+
 	return supply
 }
 


### PR DESCRIPTION
## Description

In many places, when querying supply, it gets cast to an sdk.Coin, for which having negative Amount is unsafe and not supported.

Normally, the supply of a coin should never go negative, however, with the addition of supply offsets, it could.

So this PR makes it such that if the supply + offset is negative, it returns as zero.

For example, if the supply is 100, and the offset is -200, the supplywithoffset is 0, not -100.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
