### PR TITLE
refactor: expedited proposals parameter migrations

### DIFF
--- a/x/gov/keeper/migrations.go
+++ b/x/gov/keeper/migrations.go
@@ -27,7 +27,7 @@ func (m Migrator) Migrate2to3(ctx sdk.Context) error {
 	return v3.MigrateStore(ctx, m.keeper.paramSpace)
 }
 
-// Migrate2to3 migrates from version 3 to 4.
+// Migrate3to4 migrates from version 3 to 4.
 func (m Migrator) Migrate3to4(ctx sdk.Context) error {
 	return v4.MigrateStore(ctx, m.keeper.paramSpace)
 }

--- a/x/gov/keeper/migrations.go
+++ b/x/gov/keeper/migrations.go
@@ -4,6 +4,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	v043 "github.com/cosmos/cosmos-sdk/x/gov/legacy/v043"
 	v3 "github.com/cosmos/cosmos-sdk/x/gov/legacy/v3"
+	v4 "github.com/cosmos/cosmos-sdk/x/gov/legacy/v4"
 )
 
 // Migrator is a struct for handling in-place store migrations.
@@ -24,4 +25,9 @@ func (m Migrator) Migrate1to2(ctx sdk.Context) error {
 // Migrate2to3 migrates from version 2 to 3.
 func (m Migrator) Migrate2to3(ctx sdk.Context) error {
 	return v3.MigrateStore(ctx, m.keeper.paramSpace)
+}
+
+// Migrate2to3 migrates from version 3 to 4.
+func (m Migrator) Migrate3to4(ctx sdk.Context) error {
+	return v4.MigrateStore(ctx, m.keeper.paramSpace)
 }

--- a/x/gov/legacy/v4/export_test.go
+++ b/x/gov/legacy/v4/export_test.go
@@ -1,6 +1,7 @@
 package v4
 
-var MinInitialDepositRatio = minInitialDepositRatio
-var MinExpeditedDeposit = minExpeditedDeposit
-var ExpeditedVotingPeriod = expeditedVotingPeriod
-var ExpeditedThreshold = expeditedThreshold
+var (
+	MinExpeditedDeposit = minExpeditedDeposit
+	ExpeditedVotingPeriod = expeditedVotingPeriod
+	ExpeditedThreshold = expeditedThreshold
+)

--- a/x/gov/legacy/v4/export_test.go
+++ b/x/gov/legacy/v4/export_test.go
@@ -1,3 +1,6 @@
 package v4
 
 var MinInitialDepositRatio = minInitialDepositRatio
+var MinExpeditedDeposit = minExpeditedDeposit
+var ExpeditedVotingPeriod = expeditedVotingPeriod
+var ExpeditedThreshold = expeditedThreshold

--- a/x/gov/legacy/v4/export_test.go
+++ b/x/gov/legacy/v4/export_test.go
@@ -1,0 +1,3 @@
+package v4
+
+var MinInitialDepositRatio = minInitialDepositRatio

--- a/x/gov/legacy/v4/store.go
+++ b/x/gov/legacy/v4/store.go
@@ -34,17 +34,17 @@ func migrateParamsStore(ctx sdk.Context, paramstore types.ParamSubspace) {
 		tallyParams types.TallyParams
 	)
 
-	//Set depositParams
+	// Set depositParams
 	paramstore.Get(ctx, types.ParamStoreKeyDepositParams, &depositParams)
 	depositParams.MinExpeditedDeposit = minExpeditedDeposit
 	paramstore.Set(ctx, types.ParamStoreKeyDepositParams, depositParams)
 
-	//Set votingParams
+	// Set votingParams
 	paramstore.Get(ctx, types.ParamStoreKeyVotingParams, &votingParams)
 	votingParams.ExpeditedVotingPeriod = expeditedVotingPeriod
 	paramstore.Set(ctx, types.ParamStoreKeyVotingParams, votingParams)
 
-	//Set tallyParams
+	// Set tallyParams
 	paramstore.Get(ctx, types.ParamStoreKeyTallyParams, &tallyParams)
 	tallyParams.ExpeditedThreshold = expeditedThreshold
 	paramstore.Set(ctx, types.ParamStoreKeyTallyParams, tallyParams)

--- a/x/gov/legacy/v4/store.go
+++ b/x/gov/legacy/v4/store.go
@@ -10,19 +10,18 @@ import (
 // If expedited, the deposit to enter voting period will be
 // increased to 5000 OSMO. The proposal will have 24 hours to achieve
 // a two-thirds majority of all staked OSMO voting power voting YES.
-var minInitialDepositRatio = sdk.NewDec(25).Quo(sdk.NewDec(100))
-var minExpeditedDeposit = sdk.NewCoins(sdk.NewCoin("osmo", sdk.NewInt(5000)))
-var expeditedVotingPeriod = time.Duration(time.Hour * 24)
-var expeditedThreshold = sdk.NewDec(2).Quo(sdk.NewDec(3))
 
-// MigrateStore performs in-place store migrations for consensus version 3
+var (
+	minExpeditedDeposit = sdk.NewCoins(sdk.NewCoin("uosmo", sdk.NewInt(5000 * 1_000_000)))
+	expeditedVotingPeriod = time.Duration(time.Hour * 24)
+	expeditedThreshold = sdk.NewDec(2).Quo(sdk.NewDec(3))
+)
+
+// MigrateStore performs in-place store migrations for consensus version 4
 // in the gov module.
-// Please note that this is the first version that switches from using
-// SDK versioning (v043 etc) for package names to consensus versioning
-// of the gov module.
 // The migration includes:
 //
-// - Setting the minimum deposit param in the paramstore.
+// - Setting the expedited proposals params in the paramstore.
 func MigrateStore(ctx sdk.Context, paramstore types.ParamSubspace) error {
 	migrateParamsStore(ctx, paramstore)
 	return nil
@@ -35,7 +34,6 @@ func migrateParamsStore(ctx sdk.Context, paramstore types.ParamSubspace) {
 
 	//Set depositParams
 	paramstore.Get(ctx, types.ParamStoreKeyDepositParams, &depositParams)
-	depositParams.MinInitialDepositRatio = minInitialDepositRatio
 	depositParams.MinExpeditedDeposit = minExpeditedDeposit
 	paramstore.Set(ctx, types.ParamStoreKeyDepositParams, depositParams)
 

--- a/x/gov/legacy/v4/store.go
+++ b/x/gov/legacy/v4/store.go
@@ -28,9 +28,11 @@ func MigrateStore(ctx sdk.Context, paramstore types.ParamSubspace) error {
 }
 
 func migrateParamsStore(ctx sdk.Context, paramstore types.ParamSubspace) {
-	var depositParams types.DepositParams
-	var votingParams types.VotingParams
-	var tallyParams types.TallyParams
+	var (
+		depositParams types.DepositParams 
+		votingParams types.VotingParams 
+		tallyParams types.TallyParams
+	)
 
 	//Set depositParams
 	paramstore.Get(ctx, types.ParamStoreKeyDepositParams, &depositParams)

--- a/x/gov/legacy/v4/store.go
+++ b/x/gov/legacy/v4/store.go
@@ -1,11 +1,19 @@
 package v4
 
 import (
+	"time"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/gov/types"
 )
 
+// If expedited, the deposit to enter voting period will be
+// increased to 5000 OSMO. The proposal will have 24 hours to achieve
+// a two-thirds majority of all staked OSMO voting power voting YES.
 var minInitialDepositRatio = sdk.NewDec(25).Quo(sdk.NewDec(100))
+var minExpeditedDeposit = sdk.NewCoins(sdk.NewCoin("osmo", sdk.NewInt(5000)))
+var expeditedVotingPeriod = time.Duration(time.Hour * 24)
+var expeditedThreshold = sdk.NewDec(2).Quo(sdk.NewDec(3))
 
 // MigrateStore performs in-place store migrations for consensus version 3
 // in the gov module.
@@ -22,7 +30,22 @@ func MigrateStore(ctx sdk.Context, paramstore types.ParamSubspace) error {
 
 func migrateParamsStore(ctx sdk.Context, paramstore types.ParamSubspace) {
 	var depositParams types.DepositParams
+	var votingParams types.VotingParams
+	var tallyParams types.TallyParams
+
+	//Set depositParams
 	paramstore.Get(ctx, types.ParamStoreKeyDepositParams, &depositParams)
 	depositParams.MinInitialDepositRatio = minInitialDepositRatio
+	depositParams.MinExpeditedDeposit = minExpeditedDeposit
 	paramstore.Set(ctx, types.ParamStoreKeyDepositParams, depositParams)
+
+	//Set votingParams
+	paramstore.Get(ctx, types.ParamStoreKeyDepositParams, &votingParams)
+	votingParams.ExpeditedVotingPeriod = expeditedVotingPeriod
+	paramstore.Set(ctx, types.ParamStoreKeyDepositParams, votingParams)
+
+	//Set tallyParams
+	paramstore.Get(ctx, types.ParamStoreKeyDepositParams, &votingParams)
+	tallyParams.ExpeditedThreshold = expeditedThreshold
+	paramstore.Set(ctx, types.ParamStoreKeyDepositParams, votingParams)
 }

--- a/x/gov/legacy/v4/store.go
+++ b/x/gov/legacy/v4/store.go
@@ -45,7 +45,7 @@ func migrateParamsStore(ctx sdk.Context, paramstore types.ParamSubspace) {
 	paramstore.Set(ctx, types.ParamStoreKeyVotingParams, votingParams)
 
 	//Set tallyParams
-	paramstore.Get(ctx, types.ParamStoreKeyTallyParams, &votingParams)
+	paramstore.Get(ctx, types.ParamStoreKeyTallyParams, &tallyParams)
 	tallyParams.ExpeditedThreshold = expeditedThreshold
-	paramstore.Set(ctx, types.ParamStoreKeyTallyParams, votingParams)
+	paramstore.Set(ctx, types.ParamStoreKeyTallyParams, tallyParams)
 }

--- a/x/gov/legacy/v4/store.go
+++ b/x/gov/legacy/v4/store.go
@@ -42,10 +42,10 @@ func migrateParamsStore(ctx sdk.Context, paramstore types.ParamSubspace) {
 	//Set votingParams
 	paramstore.Get(ctx, types.ParamStoreKeyVotingParams, &votingParams)
 	votingParams.ExpeditedVotingPeriod = expeditedVotingPeriod
-	paramstore.Set(ctx, types.ParamStoreKeyDepositParams, votingParams)
+	paramstore.Set(ctx, types.ParamStoreKeyVotingParams, votingParams)
 
 	//Set tallyParams
 	paramstore.Get(ctx, types.ParamStoreKeyTallyParams, &votingParams)
 	tallyParams.ExpeditedThreshold = expeditedThreshold
-	paramstore.Set(ctx, types.ParamStoreKeyDepositParams, votingParams)
+	paramstore.Set(ctx, types.ParamStoreKeyTallyParams, votingParams)
 }

--- a/x/gov/legacy/v4/store.go
+++ b/x/gov/legacy/v4/store.go
@@ -40,12 +40,12 @@ func migrateParamsStore(ctx sdk.Context, paramstore types.ParamSubspace) {
 	paramstore.Set(ctx, types.ParamStoreKeyDepositParams, depositParams)
 
 	//Set votingParams
-	paramstore.Get(ctx, types.ParamStoreKeyDepositParams, &votingParams)
+	paramstore.Get(ctx, types.ParamStoreKeyVotingParams, &votingParams)
 	votingParams.ExpeditedVotingPeriod = expeditedVotingPeriod
 	paramstore.Set(ctx, types.ParamStoreKeyDepositParams, votingParams)
 
 	//Set tallyParams
-	paramstore.Get(ctx, types.ParamStoreKeyDepositParams, &votingParams)
+	paramstore.Get(ctx, types.ParamStoreKeyTallyParams, &votingParams)
 	tallyParams.ExpeditedThreshold = expeditedThreshold
 	paramstore.Set(ctx, types.ParamStoreKeyDepositParams, votingParams)
 }

--- a/x/gov/legacy/v4/store.go
+++ b/x/gov/legacy/v4/store.go
@@ -1,0 +1,28 @@
+package v4
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/gov/types"
+)
+
+var minInitialDepositRatio = sdk.NewDec(25).Quo(sdk.NewDec(100))
+
+// MigrateStore performs in-place store migrations for consensus version 3
+// in the gov module.
+// Please note that this is the first version that switches from using
+// SDK versioning (v043 etc) for package names to consensus versioning
+// of the gov module.
+// The migration includes:
+//
+// - Setting the minimum deposit param in the paramstore.
+func MigrateStore(ctx sdk.Context, paramstore types.ParamSubspace) error {
+	migrateParamsStore(ctx, paramstore)
+	return nil
+}
+
+func migrateParamsStore(ctx sdk.Context, paramstore types.ParamSubspace) {
+	var depositParams types.DepositParams
+	paramstore.Get(ctx, types.ParamStoreKeyDepositParams, &depositParams)
+	depositParams.MinInitialDepositRatio = minInitialDepositRatio
+	paramstore.Set(ctx, types.ParamStoreKeyDepositParams, depositParams)
+}

--- a/x/gov/legacy/v4/store_test.go
+++ b/x/gov/legacy/v4/store_test.go
@@ -25,7 +25,6 @@ func TestGovStoreMigrationToV4ConsensusVersion(t *testing.T) {
 
 	// We assume that all deposit params are set besides the MinInitialDepositRatio
 	originalDepositParams := types.DefaultDepositParams()
-	originalDepositParams.MinInitialDepositRatio = sdk.ZeroDec()
 	originalDepositParams.MinExpeditedDeposit = sdk.NewCoins()
 	paramstore.Set(ctx, types.ParamStoreKeyDepositParams, originalDepositParams)
 
@@ -44,7 +43,6 @@ func TestGovStoreMigrationToV4ConsensusVersion(t *testing.T) {
 	// Make sure the new params are set.
 	var depositParams types.DepositParams
 	paramstore.Get(ctx, types.ParamStoreKeyDepositParams, &depositParams)
-	require.Equal(t, v4.MinInitialDepositRatio, depositParams.MinInitialDepositRatio)
 	require.Equal(t, v4.MinExpeditedDeposit, depositParams.MinExpeditedDeposit)
 
 	var votingParams types.VotingParams

--- a/x/gov/legacy/v4/store_test.go
+++ b/x/gov/legacy/v4/store_test.go
@@ -1,0 +1,38 @@
+package v4_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cosmos/cosmos-sdk/simapp"
+	"github.com/cosmos/cosmos-sdk/testutil"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	v4 "github.com/cosmos/cosmos-sdk/x/gov/legacy/v4"
+	"github.com/cosmos/cosmos-sdk/x/gov/types"
+	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
+)
+
+func TestGovStoreMigrationToV3ConsensusVersion(t *testing.T) {
+	encCfg := simapp.MakeTestEncodingConfig()
+	govKey := sdk.NewKVStoreKey("gov")
+	transientTestKey := sdk.NewTransientStoreKey("transient_test")
+	ctx := testutil.DefaultContext(govKey, transientTestKey)
+	paramstore := paramtypes.NewSubspace(encCfg.Marshaler, encCfg.Amino, govKey, transientTestKey, "gov")
+
+	paramstore = paramstore.WithKeyTable(types.ParamKeyTable())
+
+	// We assume that all deposit params are set besdides the MinInitialDepositRatio
+	originalDepositParams := types.DefaultDepositParams()
+	originalDepositParams.MinInitialDepositRatio = sdk.ZeroDec()
+	paramstore.Set(ctx, types.ParamStoreKeyDepositParams, originalDepositParams)
+
+	// Run migrations.
+	err := v4.MigrateStore(ctx, paramstore)
+	require.NoError(t, err)
+
+	// Make sure the new param is set.
+	var depositParams types.DepositParams
+	paramstore.Get(ctx, types.ParamStoreKeyDepositParams, &depositParams)
+	require.Equal(t, v4.MinInitialDepositRatio, depositParams.MinInitialDepositRatio)
+}

--- a/x/gov/module.go
+++ b/x/gov/module.go
@@ -165,6 +165,10 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 	if err != nil {
 		panic(err)
 	}
+	cfg.RegisterMigration(types.ModuleName, 3, m.Migrate3to4)
+	if err != nil {
+		panic(err)
+	}
 }
 
 // InitGenesis performs genesis initialization for the gov module. It returns
@@ -184,7 +188,7 @@ func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.Raw
 }
 
 // ConsensusVersion implements AppModule/ConsensusVersion.
-func (AppModule) ConsensusVersion() uint64 { return 3 }
+func (AppModule) ConsensusVersion() uint64 { return 4 }
 
 // BeginBlock performs a no-op.
 func (AppModule) BeginBlock(_ sdk.Context, _ abci.RequestBeginBlock) {}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: [#2249](https://github.com/osmosis-labs/osmosis/issues/2249)

## What is the purpose of the change

For expedited proposals we added 2 new parameters:

[MinExpeditedDeposit](https://github.com/osmosis-labs/cosmos-sdk/blob/51bfa90799eee0ca476792955a33acdac88754be/x/gov/types/gov.pb.go#L382)
[ExpeditedVotingPeriod](https://github.com/osmosis-labs/cosmos-sdk/blob/51bfa90799eee0ca476792955a33acdac88754be/x/gov/types/gov.pb.go#L426)
[ExpeditedThreshold](https://github.com/osmosis-labs/cosmos-sdk/blob/51bfa90799eee0ca476792955a33acdac88754be/x/gov/types/gov.pb.go#L472)

However, these parameters have not been set / migrated to. We need to implement the migrations to set the parameters to the desired values according to: https://wallet.keplr.app/chains/osmosis/proposals/278 and its respective common wealth thread.


## Brief Changelog

expedited proposal parameter migrations are implemented in the SDK fork
parameters are set to the desired values from the gov prop
the upgraded sdk change is integrated into Osmosis
e2e upgrade tests continue to pass

## Testing and Verifying


This change is already covered by existing tests, such as the CI tests as well as tests written in gov/legacy/v4 module
  - *Added unit test that validates params settings and storage.*


## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (**yes** / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / **no**)
  - How is the feature or change documented? (**not applicable**   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)
