### PR TITLE
fix!: Cap merkelized gas used to be gas wanted + 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Changelog
 
+## [Unreleased Osmosis fork]()
+
+* Cap the `gas_used` communicated to tendermint at `gas_wanted + 1`, and emit an event with exact excess gas used.
+
 ## [Unreleased]
 
 ## [v0.45.0](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.45.0) - 2022-01-18

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -314,7 +314,7 @@ func (app *BaseApp) DeliverTx(req abci.RequestDeliverTx) abci.ResponseDeliverTx 
 		result.Events = append(result.Events, sdk.Events{newEvent}.ToABCIEvents()...)
 		gInfo.GasUsed = gInfo.GasWanted + 1
 	}
-
+	// err check must come after the gas used changes
 	if err != nil {
 		resultStr = "failed"
 		return sdkerrors.ResponseDeliverTxWithEvents(err, gInfo.GasWanted, gInfo.GasUsed, anteEvents, app.trace)

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -306,6 +306,7 @@ func (app *BaseApp) DeliverTx(req abci.RequestDeliverTx) abci.ResponseDeliverTx 
 	gInfo, result, anteEvents, err := app.runTx(runTxModeDeliver, req.Tx)
 	// cap gas used at gas wanted + 1, to reduce application sensitivity to gas when were exceeding the limit
 	// cref: https://github.com/cosmos/cosmos-sdk/issues/12788
+	// TODO: This should become a sentinel value, with ABCI updates.
 	// TODO: In the future, the entire gas wanted & gas used being communicated to Tendermint is a bad design
 	// That should be purely state machine side
 	if gInfo.GasUsed > gInfo.GasWanted {


### PR DESCRIPTION
## Description

Cref https://github.com/cosmos/cosmos-sdk/issues/12788

Caps the maximum gas_used field that gets merkelized to be gas_wanted + 1. It emits an event so folks can still use their old debugging flows (granted the entire gas debugging flow should be improved, using gas usage traces, and by getting better visualizers for them)

This should really be a sentinel value, but thats not currently possible without more involved tendermint & ecosystem changes.
In general, I think the design of the ABCI TxResults is pretty wonky, and needs to be rethought. Its unclear to me why gas used amounts are merkelized in Tendermint -- they should be deterministic across versions, but this should be checked / ensured at the application layer.

(This PR still needs tests added)

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [x] added a changelog entry to `CHANGELOG.md`
- [x] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
