### PR TITLE
feat: add method to modify crisis keeper invariant route

### DIFF
--- a/simapp/config.go
+++ b/simapp/config.go
@@ -8,20 +8,21 @@ import (
 
 // List of available flags for the simulator
 var (
-	FlagGenesisFileValue        string
-	FlagParamsFileValue         string
-	FlagExportParamsPathValue   string
-	FlagExportParamsHeightValue int
-	FlagExportStatePathValue    string
-	FlagExportStatsPathValue    string
-	FlagSeedValue               int64
-	FlagInitialBlockHeightValue int
-	FlagNumBlocksValue          int
-	FlagBlockSizeValue          int
-	FlagLeanValue               bool
-	FlagCommitValue             bool
-	FlagOnOperationValue        bool // TODO: Remove in favor of binary search for invariant violation
-	FlagAllInvariantsValue      bool
+	FlagGenesisFileValue                string
+	FlagParamsFileValue                 string
+	FlagExportParamsPathValue           string
+	FlagExportParamsHeightValue         int
+	FlagExportStatePathValue            string
+	FlagExportStatsPathValue            string
+	FlagExcludeLongInvariantProbability float64
+	FlagSeedValue                       int64
+	FlagInitialBlockHeightValue         int
+	FlagNumBlocksValue                  int
+	FlagBlockSizeValue                  int
+	FlagLeanValue                       bool
+	FlagCommitValue                     bool
+	FlagOnOperationValue                bool // TODO: Remove in favor of binary search for invariant violation
+	FlagAllInvariantsValue              bool
 
 	FlagEnabledValue     bool
 	FlagVerboseValue     bool
@@ -38,6 +39,7 @@ func GetSimulatorFlags() {
 	flag.IntVar(&FlagExportParamsHeightValue, "ExportParamsHeight", 0, "height to which export the randomly generated params")
 	flag.StringVar(&FlagExportStatePathValue, "ExportStatePath", "", "custom file path to save the exported app state JSON")
 	flag.StringVar(&FlagExportStatsPathValue, "ExportStatsPath", "", "custom file path to save the exported simulation statistics JSON")
+	flag.Float64Var(&FlagExcludeLongInvariantProbability, "ExcludeLongInvariant", 0, "probability simulator will skip longer invariants that run every period value")
 	flag.Int64Var(&FlagSeedValue, "Seed", 42, "simulation random seed")
 	flag.IntVar(&FlagInitialBlockHeightValue, "InitialBlockHeight", 1, "initial block to start the simulation")
 	flag.IntVar(&FlagNumBlocksValue, "NumBlocks", 500, "number of new blocks to simulate from the initial block height")
@@ -57,19 +59,20 @@ func GetSimulatorFlags() {
 // NewConfigFromFlags creates a simulation from the retrieved values of the flags.
 func NewConfigFromFlags() simulation.Config {
 	return simulation.Config{
-		GenesisFile:        FlagGenesisFileValue,
-		ParamsFile:         FlagParamsFileValue,
-		ExportParamsPath:   FlagExportParamsPathValue,
-		ExportParamsHeight: FlagExportParamsHeightValue,
-		ExportStatePath:    FlagExportStatePathValue,
-		ExportStatsPath:    FlagExportStatsPathValue,
-		Seed:               FlagSeedValue,
-		InitialBlockHeight: FlagInitialBlockHeightValue,
-		NumBlocks:          FlagNumBlocksValue,
-		BlockSize:          FlagBlockSizeValue,
-		Lean:               FlagLeanValue,
-		Commit:             FlagCommitValue,
-		OnOperation:        FlagOnOperationValue,
-		AllInvariants:      FlagAllInvariantsValue,
+		GenesisFile:          FlagGenesisFileValue,
+		ParamsFile:           FlagParamsFileValue,
+		ExportParamsPath:     FlagExportParamsPathValue,
+		ExportParamsHeight:   FlagExportParamsHeightValue,
+		ExportStatePath:      FlagExportStatePathValue,
+		ExportStatsPath:      FlagExportStatsPathValue,
+		ExcludeLongInvariant: FlagExcludeLongInvariantProbability,
+		Seed:                 FlagSeedValue,
+		InitialBlockHeight:   FlagInitialBlockHeightValue,
+		NumBlocks:            FlagNumBlocksValue,
+		BlockSize:            FlagBlockSizeValue,
+		Lean:                 FlagLeanValue,
+		Commit:               FlagCommitValue,
+		OnOperation:          FlagOnOperationValue,
+		AllInvariants:        FlagAllInvariantsValue,
 	}
 }

--- a/types/simulation/config.go
+++ b/types/simulation/config.go
@@ -10,6 +10,8 @@ type Config struct {
 	ExportStatePath    string // custom file path to save the exported app state JSON
 	ExportStatsPath    string // custom file path to save the exported simulation statistics JSON
 
+	ExcludeLongInvariant float64 // probability simulator will skip longer invariants that run every period value
+
 	Seed               int64  // simulation random seed
 	InitialBlockHeight int    // initial block to start the simulation
 	NumBlocks          int    // number of new blocks to simulate from the initial block height

--- a/x/crisis/keeper/keeper.go
+++ b/x/crisis/keeper/keeper.go
@@ -58,6 +58,11 @@ func (k Keeper) Routes() []types.InvarRoute {
 	return k.routes
 }
 
+// NewRoutes - modifies the keeper's invariant routes
+func (k *Keeper) NewRoutes(routes []types.InvarRoute) {
+	k.routes = routes
+}
+
 // Invariants returns a copy of all registered Crisis keeper invariants.
 func (k Keeper) Invariants() []sdk.Invariant {
 	invars := make([]sdk.Invariant, len(k.routes))


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

One requirement of the simulator epic is to speed up sim runs while still checking invariants at regular intervals. The current decision was to have some probability that the longer invariants run while still having the short invariants run every period value. In order to achieve this, we must be able to change the crisis check Routes that get set during initialization mid simulation. AFAIK the only way to achieve this was to add the NewRoutes keeper method in this PR. Since I was already making an sdk change, I decided to also make the FlagExcludeLongInvariantProbability instead of just defining it locally in the osmosis simulator, however this can be removed and defined on the Osmosis side if this is desired!


## Brief Changelog

- Adds NewRoutes keeper method to change invariant check routes after initialization
- Adds FlagExcludeLongInvariantProbability as part of the sdk simApp (can revert this change as not required)


## Testing and Verifying

This change is already covered by existing tests

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable
