### PR TITLE
fix: GetSupplyWithOffset returns int

### DIFF
--- a/x/bank/keeper/grpc_query.go
+++ b/x/bank/keeper/grpc_query.go
@@ -105,9 +105,9 @@ func (q Querier) SupplyOf(c context.Context, req *types.QuerySupplyOfRequest) (*
 
 	ctx := sdk.UnwrapSDKContext(c)
 	supply := q.GetSupplyWithOffset(ctx, req.Denom)
-	if supply.IsNegative() {
-		return nil, status.Errorf(codes.OutOfRange, "resulting supply is negative: %v", supply)
-	}
+	// if supply.IsNegative() {
+	// 	return nil, status.Errorf(codes.OutOfRange, "resulting supply is negative: %v", supply)
+	// }
 
 	return &types.QuerySupplyOfResponse{Amount: sdk.NewCoin(req.Denom, supply)}, nil
 }

--- a/x/bank/keeper/grpc_query.go
+++ b/x/bank/keeper/grpc_query.go
@@ -105,9 +105,9 @@ func (q Querier) SupplyOf(c context.Context, req *types.QuerySupplyOfRequest) (*
 
 	ctx := sdk.UnwrapSDKContext(c)
 	supply := q.GetSupplyWithOffset(ctx, req.Denom)
-	// if supply.IsNegative() {
-	// 	return nil, status.Errorf(codes.OutOfRange, "resulting supply is negative: %v", supply)
-	// }
+	if supply.IsNegative() {
+		return nil, status.Errorf(codes.OutOfRange, "resulting supply is negative: %v", supply)
+	}
 
 	return &types.QuerySupplyOfResponse{Amount: sdk.NewCoin(req.Denom, supply)}, nil
 }

--- a/x/bank/keeper/grpc_query.go
+++ b/x/bank/keeper/grpc_query.go
@@ -105,8 +105,11 @@ func (q Querier) SupplyOf(c context.Context, req *types.QuerySupplyOfRequest) (*
 
 	ctx := sdk.UnwrapSDKContext(c)
 	supply := q.GetSupplyWithOffset(ctx, req.Denom)
+	if supply.IsNegative() {
+		return nil, status.Errorf(codes.OutOfRange, "resulting supply is negative: %v", supply)
+	}
 
-	return &types.QuerySupplyOfResponse{Amount: sdk.NewCoin(req.Denom, supply.Amount)}, nil
+	return &types.QuerySupplyOfResponse{Amount: sdk.NewCoin(req.Denom, supply)}, nil
 }
 
 // TotalSupply implements the Query/TotalSupplyWithoutOffset gRPC method

--- a/x/bank/keeper/grpc_query_test.go
+++ b/x/bank/keeper/grpc_query_test.go
@@ -82,6 +82,7 @@ func (suite *IntegrationTestSuite) TestQueryAllBalances() {
 	}
 	req = types.NewQueryAllBalancesRequest(addr, pageReq)
 	res, err = queryClient.AllBalances(gocontext.Background(), req)
+	suite.Require().NoError(err)
 	suite.Equal(res.Balances.Len(), 1)
 	suite.Nil(res.Pagination.NextKey)
 }

--- a/x/bank/keeper/grpc_query_test.go
+++ b/x/bank/keeper/grpc_query_test.go
@@ -150,14 +150,6 @@ func (suite *IntegrationTestSuite) TestQueryTotalSupplyOf() {
 	suite.Require().NotNil(res2)
 
 	suite.Require().Equal(test1Supply, res2.Amount)
-
-	// try to make SupplyWithOffset negative, should return as 0
-	app.BankKeeper.AddSupplyOffset(ctx, "test1", sdk.NewInt(-100000000000))
-	res, err = queryClient.SupplyOf(gocontext.Background(), &types.QuerySupplyOfRequest{Denom: test1Supply.Denom})
-	suite.Require().NoError(err)
-	suite.Require().NotNil(res)
-
-	suite.Require().Equal(sdk.NewInt64Coin("test1", 0), res.Amount)
 }
 
 func (suite *IntegrationTestSuite) TestQueryParams() {

--- a/x/bank/keeper/keeper.go
+++ b/x/bank/keeper/keeper.go
@@ -32,7 +32,7 @@ type Keeper interface {
 	IterateTotalSupply(ctx sdk.Context, cb func(sdk.Coin) bool)
 	GetSupplyOffset(ctx sdk.Context, denom string) sdk.Int
 	AddSupplyOffset(ctx sdk.Context, denom string, offsetAmount sdk.Int)
-	GetSupplyWithOffset(ctx sdk.Context, denom string) sdk.Coin
+	GetSupplyWithOffset(ctx sdk.Context, denom string) sdk.Int
 	GetPaginatedTotalSupplyWithOffsets(ctx sdk.Context, pagination *query.PageRequest) (sdk.Coins, *query.PageResponse, error)
 	IterateTotalSupplyWithOffsets(ctx sdk.Context, cb func(sdk.Coin) bool)
 	GetBaseDenom(ctx sdk.Context, denom string) (string, bool)

--- a/x/bank/keeper/keeper_test.go
+++ b/x/bank/keeper/keeper_test.go
@@ -288,6 +288,7 @@ func (suite *IntegrationTestSuite) TestSupply_BurnCoins() {
 		Require().
 		NoError(keeper.MintCoins(ctx, authtypes.Minter, initCoins))
 	supplyAfterInflation, _, err := keeper.GetPaginatedTotalSupply(ctx, &query.PageRequest{})
+	suite.Require().NoError(err)
 
 	suite.Require().Panics(func() { keeper.BurnCoins(ctx, "", initCoins) }, "no module account")                    // nolint:errcheck
 	suite.Require().Panics(func() { keeper.BurnCoins(ctx, authtypes.Minter, initCoins) }, "invalid permission")     // nolint:errcheck
@@ -313,8 +314,8 @@ func (suite *IntegrationTestSuite) TestSupply_BurnCoins() {
 	authKeeper.SetModuleAccount(ctx, multiPermAcc)
 
 	err = keeper.BurnCoins(ctx, multiPermAcc.GetName(), initCoins)
-	supplyAfterBurn, _, err = keeper.GetPaginatedTotalSupply(ctx, &query.PageRequest{})
 	suite.Require().NoError(err)
+	supplyAfterBurn, _, err = keeper.GetPaginatedTotalSupply(ctx, &query.PageRequest{})
 	suite.Require().NoError(err)
 	suite.Require().Equal(sdk.NewCoins().String(), getCoinsByName(ctx, keeper, authKeeper, multiPermAcc.GetName()).String())
 	suite.Require().Equal(supplyAfterInflation.Sub(initCoins), supplyAfterBurn)

--- a/x/bank/keeper/supply_offset.go
+++ b/x/bank/keeper/supply_offset.go
@@ -54,15 +54,10 @@ func (k BaseKeeper) AddSupplyOffset(ctx sdk.Context, denom string, offsetAmount 
 // GetSupplyWithOffset retrieves the Supply of a denom and offsets it by SupplyOffset
 // If SupplyWithOffset is negative, it returns 0.  This is because sdk.Coin is not valid
 // with a negative amount
-func (k BaseKeeper) GetSupplyWithOffset(ctx sdk.Context, denom string) sdk.Coin {
+func (k BaseKeeper) GetSupplyWithOffset(ctx sdk.Context, denom string) sdk.Int {
 	supply := k.GetSupply(ctx, denom)
 	supply.Amount = supply.Amount.Add(k.GetSupplyOffset(ctx, denom))
-
-	if supply.Amount.IsNegative() {
-		supply.Amount = sdk.ZeroInt()
-	}
-
-	return supply
+	return supply.Amount
 }
 
 // GetPaginatedTotalSupplyWithOffsets queries for the supply with offset, ignoring 0 coins, with a given pagination


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Previously we made a PR that returned a zero coin value if the resulting supply was negative. This prevents us from checking what this offset actually is in tests such as this
https://github.com/osmosis-labs/osmosis/blob/main/x/mint/keeper/keeper_test.go#L354


## Brief Changelog

- returns an sdk.Int instead of a coin
- fixes calls to this method to accept new return value


## Testing and Verifying

This change is already covered by existing tests

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable
