### PR TITLE
fix: added new constructor for genesis supply that matches upstream

### DIFF
--- a/simapp/test_helpers.go
+++ b/simapp/test_helpers.go
@@ -141,7 +141,7 @@ func SetupWithGenesisValSet(t *testing.T, valSet *tmtypes.ValidatorSet, genAccs 
 	})
 
 	// update total supply
-	bankGenesis := banktypes.NewGenesisState(banktypes.DefaultGenesisState().Params, balances, totalSupply, []banktypes.Metadata{}, []banktypes.GenesisSupplyOffset{})
+	bankGenesis := banktypes.NewGenesisState(banktypes.DefaultGenesisState().Params, balances, totalSupply, []banktypes.Metadata{})
 	genesisState[banktypes.ModuleName] = app.AppCodec().MustMarshalJSON(bankGenesis)
 
 	stateBytes, err := json.MarshalIndent(genesisState, "", " ")
@@ -180,7 +180,7 @@ func SetupWithGenesisAccounts(genAccs []authtypes.GenesisAccount, balances ...ba
 		totalSupply = totalSupply.Add(b.Coins...)
 	}
 
-	bankGenesis := banktypes.NewGenesisState(banktypes.DefaultGenesisState().Params, balances, totalSupply, []banktypes.Metadata{}, []banktypes.GenesisSupplyOffset{})
+	bankGenesis := banktypes.NewGenesisState(banktypes.DefaultGenesisState().Params, balances, totalSupply, []banktypes.Metadata{})
 	genesisState[banktypes.ModuleName] = app.AppCodec().MustMarshalJSON(bankGenesis)
 
 	stateBytes, err := json.MarshalIndent(genesisState, "", " ")

--- a/x/bank/keeper/genesis.go
+++ b/x/bank/keeper/genesis.go
@@ -52,7 +52,7 @@ func (k BaseKeeper) ExportGenesis(ctx sdk.Context) *types.GenesisState {
 		panic(fmt.Errorf("unable to fetch total supply %v", err))
 	}
 
-	return types.NewGenesisState(
+	return types.NewGenesisStateWithSupplyOffsets(
 		k.GetParams(ctx),
 		k.GetAccountsBalances(ctx),
 		totalSupply,

--- a/x/bank/keeper/genesis.go
+++ b/x/bank/keeper/genesis.go
@@ -52,11 +52,10 @@ func (k BaseKeeper) ExportGenesis(ctx sdk.Context) *types.GenesisState {
 		panic(fmt.Errorf("unable to fetch total supply %v", err))
 	}
 
-	return types.NewGenesisStateWithSupplyOffsets(
+	return types.NewGenesisState(
 		k.GetParams(ctx),
 		k.GetAccountsBalances(ctx),
 		totalSupply,
 		k.GetAllDenomMetaData(ctx),
-		k.getGenesisSupplyOffsets(ctx),
-	)
+	).WithSupplyOffsets(k.getGenesisSupplyOffsets(ctx))
 }

--- a/x/bank/keeper/genesis_test.go
+++ b/x/bank/keeper/genesis_test.go
@@ -83,17 +83,17 @@ func (suite *IntegrationTestSuite) TestTotalSupply() {
 	}{
 		{
 			"calculation NOT matching genesis Supply field",
-			types.NewGenesisStateWithSupplyOffsets(defaultGenesis.Params, balances, sdk.NewCoins(sdk.NewCoin("wrongcoin", sdk.NewInt(1))), defaultGenesis.DenomMetadata, defaultGenesis.SupplyOffsets),
+			types.NewGenesisState(defaultGenesis.Params, balances, sdk.NewCoins(sdk.NewCoin("wrongcoin", sdk.NewInt(1))), defaultGenesis.DenomMetadata).WithSupplyOffsets(defaultGenesis.SupplyOffsets),
 			nil, true, "genesis supply is incorrect, expected 1wrongcoin, got 21barcoin,11foocoin",
 		},
 		{
 			"calculation matches genesis Supply field",
-			types.NewGenesisStateWithSupplyOffsets(defaultGenesis.Params, balances, totalSupply, defaultGenesis.DenomMetadata, defaultGenesis.SupplyOffsets),
+			types.NewGenesisState(defaultGenesis.Params, balances, totalSupply, defaultGenesis.DenomMetadata).WithSupplyOffsets(defaultGenesis.SupplyOffsets),
 			totalSupply, false, "",
 		},
 		{
 			"calculation is correct, empty genesis Supply field",
-			types.NewGenesisStateWithSupplyOffsets(defaultGenesis.Params, balances, nil, defaultGenesis.DenomMetadata, defaultGenesis.SupplyOffsets),
+			types.NewGenesisState(defaultGenesis.Params, balances, nil, defaultGenesis.DenomMetadata).WithSupplyOffsets(defaultGenesis.SupplyOffsets),
 			totalSupply, false, "",
 		},
 	}

--- a/x/bank/keeper/genesis_test.go
+++ b/x/bank/keeper/genesis_test.go
@@ -83,17 +83,17 @@ func (suite *IntegrationTestSuite) TestTotalSupply() {
 	}{
 		{
 			"calculation NOT matching genesis Supply field",
-			types.NewGenesisState(defaultGenesis.Params, balances, sdk.NewCoins(sdk.NewCoin("wrongcoin", sdk.NewInt(1))), defaultGenesis.DenomMetadata, defaultGenesis.SupplyOffsets),
+			types.NewGenesisStateWithSupplyOffsets(defaultGenesis.Params, balances, sdk.NewCoins(sdk.NewCoin("wrongcoin", sdk.NewInt(1))), defaultGenesis.DenomMetadata, defaultGenesis.SupplyOffsets),
 			nil, true, "genesis supply is incorrect, expected 1wrongcoin, got 21barcoin,11foocoin",
 		},
 		{
 			"calculation matches genesis Supply field",
-			types.NewGenesisState(defaultGenesis.Params, balances, totalSupply, defaultGenesis.DenomMetadata, defaultGenesis.SupplyOffsets),
+			types.NewGenesisStateWithSupplyOffsets(defaultGenesis.Params, balances, totalSupply, defaultGenesis.DenomMetadata, defaultGenesis.SupplyOffsets),
 			totalSupply, false, "",
 		},
 		{
 			"calculation is correct, empty genesis Supply field",
-			types.NewGenesisState(defaultGenesis.Params, balances, nil, defaultGenesis.DenomMetadata, defaultGenesis.SupplyOffsets),
+			types.NewGenesisStateWithSupplyOffsets(defaultGenesis.Params, balances, nil, defaultGenesis.DenomMetadata, defaultGenesis.SupplyOffsets),
 			totalSupply, false, "",
 		},
 	}

--- a/x/bank/types/genesis.go
+++ b/x/bank/types/genesis.go
@@ -73,16 +73,10 @@ func NewGenesisState(params Params, balances []Balance, supply sdk.Coins,
 	}
 }
 
-// NewGenesisState creates a new genesis state with supply offsets
-func NewGenesisStateWithSupplyOffsets(params Params, balances []Balance, supply sdk.Coins,
-	denomMetaData []Metadata, supplyOffsets []GenesisSupplyOffset) *GenesisState {
-	return &GenesisState{
-		Params:        params,
-		Balances:      balances,
-		Supply:        supply,
-		DenomMetadata: denomMetaData,
-		SupplyOffsets: supplyOffsets,
-	}
+// WithSupplyOffsets adds supply offsets to a genesis state
+func (gs *GenesisState) WithSupplyOffsets(supplyOffsets []GenesisSupplyOffset) *GenesisState {
+	gs.SupplyOffsets = supplyOffsets
+	return gs
 }
 
 // DefaultGenesisState returns a default bank module genesis state.

--- a/x/bank/types/genesis.go
+++ b/x/bank/types/genesis.go
@@ -63,6 +63,18 @@ func (gs GenesisState) Validate() error {
 
 // NewGenesisState creates a new genesis state.
 func NewGenesisState(params Params, balances []Balance, supply sdk.Coins,
+	denomMetaData []Metadata) *GenesisState {
+	return &GenesisState{
+		Params:        params,
+		Balances:      balances,
+		Supply:        supply,
+		DenomMetadata: denomMetaData,
+		SupplyOffsets: []GenesisSupplyOffset{},
+	}
+}
+
+// NewGenesisState creates a new genesis state with supply offsets
+func NewGenesisStateWithSupplyOffsets(params Params, balances []Balance, supply sdk.Coins,
 	denomMetaData []Metadata, supplyOffsets []GenesisSupplyOffset) *GenesisState {
 	return &GenesisState{
 		Params:        params,
@@ -75,7 +87,7 @@ func NewGenesisState(params Params, balances []Balance, supply sdk.Coins,
 
 // DefaultGenesisState returns a default bank module genesis state.
 func DefaultGenesisState() *GenesisState {
-	return NewGenesisState(DefaultParams(), []Balance{}, sdk.Coins{}, []Metadata{}, []GenesisSupplyOffset{})
+	return NewGenesisState(DefaultParams(), []Balance{}, sdk.Coins{}, []Metadata{})
 }
 
 // GetGenesisStateFromAppState returns x/bank GenesisState given raw application


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Needed for https://github.com/osmosis-labs/osmosis/issues/2307

## What is the purpose of the change

This is a replacement for https://github.com/osmosis-labs/cosmos-sdk/pull/305 with a cleaner change history. 

The sdk fork is using GenesisSupplyOffsets in the banktypes.NewGenesisState() constructor. This is incompatible with the ibc-go testing package which expects the new signature (https://github.com/cosmos/ibc-go/tree/main/testing).


## Brief Changelog

 - Updated the constructor to match the expected interface.
 - Added a new constructor that can be used for the previous behaviour


## Testing and Verifying

This change is already covered by existing tests

## Documentation and Release Note
 - Does this pull request introduce a new feature or user-facing behavior changes? (no)
 - Is a relevant changelog entry added to the Unreleased section in CHANGELOG.md? (no)
 - How is the feature or change documented? (not applicable)
