### PR TITLE
chore: Revert "chore: backport #13063 from cosmos/cosmos-sdk #323"

### DIFF
--- a/types/context.go
+++ b/types/context.go
@@ -262,18 +262,11 @@ func (c Context) TransientStore(key StoreKey) KVStore {
 
 // CacheContext returns a new Context with the multi-store cached and a new
 // EventManager. The cached context is written to the context when writeCache
-// is called. Note, events are automatically emitted on the parent context's
-// EventManager when the caller executes the write.
+// is called.
 func (c Context) CacheContext() (cc Context, writeCache func()) {
 	cms := c.MultiStore().CacheMultiStore()
 	cc = c.WithMultiStore(cms).WithEventManager(NewEventManager())
-
-	writeCache = func() {
-		c.EventManager().EmitEvents(cc.EventManager().Events())
-		cms.Write()
-	}
-
-	return cc, writeCache
+	return cc, cms.Write
 }
 
 // ContextKey defines a type alias for a stdlib Context key.

--- a/types/context_test.go
+++ b/types/context_test.go
@@ -42,10 +42,6 @@ func (s *contextTestSuite) TestCacheContext() {
 	s.Require().Equal(v1, cstore.Get(k1))
 	s.Require().Nil(cstore.Get(k2))
 
-	// emit some events
-	cctx.EventManager().EmitEvent(types.NewEvent("foo", types.NewAttribute("key", "value")))
-	cctx.EventManager().EmitEvent(types.NewEvent("bar", types.NewAttribute("key", "value")))
-
 	cstore.Set(k2, v2)
 	s.Require().Equal(v2, cstore.Get(k2))
 	s.Require().Nil(store.Get(k2))
@@ -53,7 +49,6 @@ func (s *contextTestSuite) TestCacheContext() {
 	write()
 
 	s.Require().Equal(v2, store.Get(k2))
-	s.Require().Len(ctx.EventManager().Events(), 2)
 }
 
 func (s *contextTestSuite) TestLogContext() {

--- a/x/gov/abci.go
+++ b/x/gov/abci.go
@@ -77,6 +77,12 @@ func EndBlocker(ctx sdk.Context, keeper keeper.Keeper) {
 				tagValue = types.AttributeValueProposalPassed
 				logMsg = "passed"
 
+				// The cached context is created with a new EventManager. However, since
+				// the proposal handler execution was successful, we want to track/keep
+				// any events emitted, so we re-emit to "merge" the events into the
+				// original Context's EventManager.
+				ctx.EventManager().EmitEvents(cacheCtx.EventManager().Events())
+
 				// write state to the underlying multi-store
 				writeCache()
 			} else {


### PR DESCRIPTION
This reverts commit 870132d311d162fdbe0e92fcc0a42ee3889afd0d.

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

It seems that this change broke some of the tests related to:
https://github.com/cosmos/ibc-go/blob/9fa6008f0b8240164e4c3632dbf1c29f744b58eb/modules/core/keeper/msg_server.go#L391-L403

Reverting temporarily to unblock v12


## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.


## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable
