### PR TITLE
chore: mergify backport config for v12

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -70,11 +70,11 @@ pull_request_rules:
       backport:
         branches:
           - v0.45.0x-osmo-v9
-  - name: backport patches to v0.45.0x-osmo-v11 branch
+  - name: backport patches to v12.x branch
     conditions:
       - base=osmosis-main
-      - label=A:backport/v0.45.0x-osmo-v11
+      - label=A:backport/v12.x
     actions:
       backport:
         branches:
-          - v0.45.0x-osmo-v11
+          - v12.x


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

For v12, we decided to switch the branch name to only `v12.x` from the older `v0.45.0x-osmo-v12` pattern.
This updates the backport configuration for the branch.

`v0.45.0x-osmo-v11` was never used so it is replaced

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable
