### PR TITLE
fix: ICA export genesis patch

### DIFF
--- a/x/auth/types/genesis.go
+++ b/x/auth/types/genesis.go
@@ -33,6 +33,9 @@ func NewGenesisState(params Params, accounts GenesisAccounts) *GenesisState {
 func (g GenesisState) UnpackInterfaces(unpacker types.AnyUnpacker) error {
 	for _, any := range g.Accounts {
 		var account GenesisAccount
+		if any.TypeUrl == "/ibc.applications.interchain_accounts.v1.InterchainAccount" {
+			continue
+		}
 		err := unpacker.UnpackAny(any, &account)
 		if err != nil {
 			return err


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

During v11 I had a custom branch I and others used to get passed an ICA bug when doing a state export. This implements the fix in our v11 sdk fork which will then be backported to v11x (and maybe a minor release?) so that if someone needs to state export v11 height in the future they are able to.

