### PR TITLE
feat: query module hashes by height

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -817,6 +817,7 @@ func handleQueryStore(app *BaseApp, path []string, req abci.RequestQuery) abci.R
 
 	if path[1] == "test" {
 		res := queryable.Query(req)
+		res.Height = req.Height
 
 		commitInfo, err := app.cms.GetCommitInfoFromDb(res.Height)
 		fmt.Printf("ADAM HEIGHT %v \n", res.Height)

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -849,7 +849,6 @@ func handleQueryStore(app *BaseApp, path []string, req abci.RequestQuery) abci.R
 			Value:     bz,
 		}
 	}
-
 	return resp
 
 }

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -822,6 +822,7 @@ func handleQueryStore(app *BaseApp, path []string, req abci.RequestQuery) abci.R
 			),
 		)
 	}
+	req.Path = "/" + strings.Join(path[1:], "/")
 
 	resp := queryable.Query(req)
 	resp.Height = req.Height

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -830,7 +830,6 @@ func handleQueryStore(app *BaseApp, path []string, req abci.RequestQuery) abci.R
 
 	if path[1] == "hashes" {
 		commitInfo, err := app.cms.GetCommitInfoFromDb(resp.Height)
-
 		if err != nil {
 			return sdkerrors.QueryResult(err)
 		}

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -819,6 +819,9 @@ func handleQueryStore(app *BaseApp, path []string, req abci.RequestQuery) abci.R
 		res := queryable.Query(req)
 
 		commitInfo, err := app.cms.GetCommitInfoFromDb(res.Height)
+		fmt.Printf("ADAM HEIGHT %v \n", res.Height)
+		fmt.Printf("ADAM ERR %v \n", err)
+		fmt.Printf("ADAM TEST %v \n", commitInfo)
 		if err != nil {
 			return sdkerrors.QueryResult(err)
 		}

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -826,8 +826,12 @@ func handleQueryStore(app *BaseApp, path []string, req abci.RequestQuery) abci.R
 		if err != nil {
 			return sdkerrors.QueryResult(err)
 		}
+		bz, err := codec.ProtoMarshalJSON(commitInfo, app.interfaceRegistry)
+		if err != nil {
+			return sdkerrors.QueryResult(sdkerrors.Wrap(err, "failed to JSON encode simulation response"))
+		}
 		fmt.Printf("ADAM TEST %v \n", commitInfo)
-		responseValue, _ := commitInfo.Marshal()
+		//responseValue, _ := commitInfo.Marshal()
 
 		// response := app.ListSnapshots(abci.RequestListSnapshots{})
 
@@ -839,7 +843,7 @@ func handleQueryStore(app *BaseApp, path []string, req abci.RequestQuery) abci.R
 		return abci.ResponseQuery{
 			Codespace: sdkerrors.RootCodespace,
 			Height:    req.Height,
-			Value:     responseValue,
+			Value:     bz,
 		}
 	}
 

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -814,6 +814,8 @@ func handleQueryStore(app *BaseApp, path []string, req abci.RequestQuery) abci.R
 		return sdkerrors.QueryResult(sdkerrors.Wrap(sdkerrors.ErrUnknownRequest, "multistore doesn't support queries"))
 	}
 
+	req.Path = "/" + strings.Join(path[1:], "/")
+
 	if req.Height <= 1 && req.Prove {
 		return sdkerrors.QueryResult(
 			sdkerrors.Wrap(
@@ -822,7 +824,6 @@ func handleQueryStore(app *BaseApp, path []string, req abci.RequestQuery) abci.R
 			),
 		)
 	}
-	req.Path = "/" + strings.Join(path[1:], "/")
 
 	resp := queryable.Query(req)
 	resp.Height = req.Height

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -813,6 +813,31 @@ func handleQueryStore(app *BaseApp, path []string, req abci.RequestQuery) abci.R
 	if !ok {
 		return sdkerrors.QueryResult(sdkerrors.Wrap(sdkerrors.ErrUnknownRequest, "multistore doesn't support queries"))
 	}
+	fmt.Printf("ADAM TESTING")
+
+	if path[1] == "test" {
+		res := queryable.Query(req)
+
+		commitInfo, err := app.cms.GetCommitInfoFromDb(res.Height)
+		if err != nil {
+			return sdkerrors.QueryResult(err)
+		}
+		fmt.Printf("ADAM TEST %v \n", commitInfo)
+		responseValue, _ := commitInfo.Marshal()
+
+		// response := app.ListSnapshots(abci.RequestListSnapshots{})
+
+		// responseValue, err = json.Marshal(response)
+		// if err != nil {
+		// 	sdkerrors.QueryResult(sdkerrors.Wrap(err, fmt.Sprintf("failed to marshal list snapshots response %v", response)))
+		// }
+
+		return abci.ResponseQuery{
+			Codespace: sdkerrors.RootCodespace,
+			Height:    req.Height,
+			Value:     responseValue,
+		}
+	}
 
 	req.Path = "/" + strings.Join(path[1:], "/")
 

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -828,7 +828,7 @@ func handleQueryStore(app *BaseApp, path []string, req abci.RequestQuery) abci.R
 	resp := queryable.Query(req)
 	resp.Height = req.Height
 
-	if path[1] == "hashes" {
+	if path[1] == "info" {
 		commitInfo, err := app.cms.GetCommitInfoFromDB(resp.Height)
 		if err != nil {
 			return sdkerrors.QueryResult(err)

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -25,6 +25,7 @@ import (
 )
 
 const initialAppVersion = 0
+const StoreInfoPath = "info"
 
 type AppVersionError struct {
 	Actual  uint64
@@ -808,7 +809,6 @@ func handleQueryApp(app *BaseApp, path []string, req abci.RequestQuery) abci.Res
 }
 
 func handleQueryStore(app *BaseApp, path []string, req abci.RequestQuery) abci.ResponseQuery {
-	const storeInfoPath = "info"
 	// "/store" prefix for store queries
 	queryable, ok := app.cms.(sdk.Queryable)
 	if !ok {
@@ -829,7 +829,7 @@ func handleQueryStore(app *BaseApp, path []string, req abci.RequestQuery) abci.R
 	resp := queryable.Query(req)
 	resp.Height = req.Height
 
-	if path[1] == storeInfoPath {
+	if path[1] == StoreInfoPath {
 		commitInfo, err := app.cms.GetCommitInfoFromDB(resp.Height)
 		if err != nil {
 			return sdkerrors.QueryResult(err)

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -826,6 +826,11 @@ func handleQueryStore(app *BaseApp, path []string, req abci.RequestQuery) abci.R
 		if err != nil {
 			return sdkerrors.QueryResult(err)
 		}
+
+		sort.Slice(commitInfo.StoreInfos, func(i, j int) bool {
+			return commitInfo.StoreInfos[i].Name < commitInfo.StoreInfos[j].Name
+		})
+
 		bz, err := codec.ProtoMarshalJSON(commitInfo, app.interfaceRegistry)
 		if err != nil {
 			return sdkerrors.QueryResult(sdkerrors.Wrap(err, "failed to JSON encode simulation response"))

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -829,7 +829,7 @@ func handleQueryStore(app *BaseApp, path []string, req abci.RequestQuery) abci.R
 	resp.Height = req.Height
 
 	if path[1] == "hashes" {
-		commitInfo, err := app.cms.GetCommitInfoFromDb(resp.Height)
+		commitInfo, err := app.cms.GetCommitInfoFromDB(resp.Height)
 		if err != nil {
 			return sdkerrors.QueryResult(err)
 		}

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -808,6 +808,7 @@ func handleQueryApp(app *BaseApp, path []string, req abci.RequestQuery) abci.Res
 }
 
 func handleQueryStore(app *BaseApp, path []string, req abci.RequestQuery) abci.ResponseQuery {
+	const storeInfoPath = "info"
 	// "/store" prefix for store queries
 	queryable, ok := app.cms.(sdk.Queryable)
 	if !ok {
@@ -828,7 +829,7 @@ func handleQueryStore(app *BaseApp, path []string, req abci.RequestQuery) abci.R
 	resp := queryable.Query(req)
 	resp.Height = req.Height
 
-	if path[1] == "info" {
+	if path[1] == storeInfoPath {
 		commitInfo, err := app.cms.GetCommitInfoFromDB(resp.Height)
 		if err != nil {
 			return sdkerrors.QueryResult(err)

--- a/server/mock/store.go
+++ b/server/mock/store.go
@@ -78,6 +78,10 @@ func (ms multiStore) GetCommitKVStore(key sdk.StoreKey) sdk.CommitKVStore {
 	panic("not implemented")
 }
 
+func (ms multiStore) GetCommitInfoFromDb(ver int64) (*store.CommitInfo, error) {
+	panic("not implemented")
+}
+
 func (ms multiStore) GetCommitStore(key sdk.StoreKey) sdk.CommitStore {
 	panic("not implemented")
 }

--- a/server/mock/store.go
+++ b/server/mock/store.go
@@ -78,7 +78,7 @@ func (ms multiStore) GetCommitKVStore(key sdk.StoreKey) sdk.CommitKVStore {
 	panic("not implemented")
 }
 
-func (ms multiStore) GetCommitInfoFromDb(ver int64) (*store.CommitInfo, error) {
+func (ms multiStore) GetCommitInfoFromDB(ver int64) (*store.CommitInfo, error) {
 	panic("not implemented")
 }
 

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -207,7 +207,7 @@ func (rs *Store) loadVersion(ver int64, upgrades *types.StoreUpgrades) error {
 	// load old data if we are not version 0
 	if ver != 0 {
 		var err error
-		cInfo, err = rs.getCommitInfoFromDb(ver)
+		cInfo, err = rs.GetCommitInfoFromDb(ver)
 		if err != nil {
 			return err
 		}
@@ -625,7 +625,7 @@ func (rs *Store) Query(req abci.RequestQuery) abci.ResponseQuery {
 		return sdkerrors.QueryResult(sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "proof is unexpectedly empty; ensure height has not been pruned"))
 	}
 
-	commitInfo, err := rs.getCommitInfoFromDb(res.Height)
+	commitInfo, err := rs.GetCommitInfoFromDb(res.Height)
 	if err != nil {
 		return sdkerrors.QueryResult(err)
 	}
@@ -983,7 +983,7 @@ func (rs *Store) flushLastCommitInfo(cInfo *types.CommitInfo) {
 }
 
 // Gets commitInfo from disk.
-func (rs *Store) getCommitInfoFromDb(ver int64) (*types.CommitInfo, error) {
+func (rs *Store) GetCommitInfoFromDb(ver int64) (*types.CommitInfo, error) {
 	cInfoKey := fmt.Sprintf(commitInfoKeyFmt, ver)
 
 	bz, err := rs.db.Get([]byte(cInfoKey))
@@ -1025,7 +1025,7 @@ func (rs *Store) GetAppVersion() (uint64, error) {
 }
 
 func (rs *Store) doProofsQuery(req abci.RequestQuery) abci.ResponseQuery {
-	commitInfo, err := rs.getCommitInfoFromDb(req.Height)
+	commitInfo, err := rs.GetCommitInfoFromDb(req.Height)
 	if err != nil {
 		return sdkerrors.QueryResult(err)
 	}

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -207,7 +207,7 @@ func (rs *Store) loadVersion(ver int64, upgrades *types.StoreUpgrades) error {
 	// load old data if we are not version 0
 	if ver != 0 {
 		var err error
-		cInfo, err = rs.GetCommitInfoFromDb(ver)
+		cInfo, err = rs.GetCommitInfoFromDB(ver)
 		if err != nil {
 			return err
 		}
@@ -625,7 +625,7 @@ func (rs *Store) Query(req abci.RequestQuery) abci.ResponseQuery {
 		return sdkerrors.QueryResult(sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "proof is unexpectedly empty; ensure height has not been pruned"))
 	}
 
-	commitInfo, err := rs.GetCommitInfoFromDb(res.Height)
+	commitInfo, err := rs.GetCommitInfoFromDB(res.Height)
 	if err != nil {
 		return sdkerrors.QueryResult(err)
 	}
@@ -983,7 +983,7 @@ func (rs *Store) flushLastCommitInfo(cInfo *types.CommitInfo) {
 }
 
 // Gets commitInfo from disk.
-func (rs *Store) GetCommitInfoFromDb(ver int64) (*types.CommitInfo, error) {
+func (rs *Store) GetCommitInfoFromDB(ver int64) (*types.CommitInfo, error) {
 	cInfoKey := fmt.Sprintf(commitInfoKeyFmt, ver)
 
 	bz, err := rs.db.Get([]byte(cInfoKey))
@@ -1025,7 +1025,7 @@ func (rs *Store) GetAppVersion() (uint64, error) {
 }
 
 func (rs *Store) doProofsQuery(req abci.RequestQuery) abci.ResponseQuery {
-	commitInfo, err := rs.GetCommitInfoFromDb(req.Height)
+	commitInfo, err := rs.GetCommitInfoFromDB(req.Height)
 	if err != nil {
 		return sdkerrors.QueryResult(err)
 	}

--- a/store/rootmulti/store_test.go
+++ b/store/rootmulti/store_test.go
@@ -214,7 +214,7 @@ func TestMultistoreLoadWithUpgrade(t *testing.T) {
 	expectedCommitID := getExpectedCommitID(store, 1)
 	checkStore(t, store, expectedCommitID, commitID)
 
-	ci, err := store.GetCommitInfoFromDb(1)
+	ci, err := store.GetCommitInfoFromDB(1)
 	require.NoError(t, err)
 	require.Equal(t, int64(1), ci.Version)
 	require.Equal(t, 3, len(ci.StoreInfos))
@@ -298,7 +298,7 @@ func TestMultistoreLoadWithUpgrade(t *testing.T) {
 	require.Equal(t, v4, rl4.Get(k4))
 
 	// check commitInfo in storage
-	ci, err = store.GetCommitInfoFromDb(2)
+	ci, err = store.GetCommitInfoFromDB(2)
 	require.NoError(t, err)
 	require.Equal(t, int64(2), ci.Version)
 	require.Equal(t, 4, len(ci.StoreInfos), ci.StoreInfos)
@@ -354,7 +354,7 @@ func TestMultiStoreRestart(t *testing.T) {
 
 		multi.Commit()
 
-		cinfo, err := multi.GetCommitInfoFromDb(int64(i))
+		cinfo, err := multi.GetCommitInfoFromDB(int64(i))
 		require.NoError(t, err)
 		require.Equal(t, int64(i), cinfo.Version)
 	}
@@ -369,7 +369,7 @@ func TestMultiStoreRestart(t *testing.T) {
 
 	multi.Commit()
 
-	flushedCinfo, err := multi.GetCommitInfoFromDb(3)
+	flushedCinfo, err := multi.GetCommitInfoFromDB(3)
 	require.Nil(t, err)
 	require.NotEqual(t, initCid, flushedCinfo, "CID is different after flush to disk")
 
@@ -379,7 +379,7 @@ func TestMultiStoreRestart(t *testing.T) {
 
 	multi.Commit()
 
-	postFlushCinfo, err := multi.GetCommitInfoFromDb(4)
+	postFlushCinfo, err := multi.GetCommitInfoFromDB(4)
 	require.NoError(t, err)
 	require.Equal(t, int64(4), postFlushCinfo.Version, "Commit changed after in-memory commit")
 

--- a/store/rootmulti/store_test.go
+++ b/store/rootmulti/store_test.go
@@ -214,7 +214,7 @@ func TestMultistoreLoadWithUpgrade(t *testing.T) {
 	expectedCommitID := getExpectedCommitID(store, 1)
 	checkStore(t, store, expectedCommitID, commitID)
 
-	ci, err := store.getCommitInfoFromDb(1)
+	ci, err := store.GetCommitInfoFromDb(1)
 	require.NoError(t, err)
 	require.Equal(t, int64(1), ci.Version)
 	require.Equal(t, 3, len(ci.StoreInfos))
@@ -298,7 +298,7 @@ func TestMultistoreLoadWithUpgrade(t *testing.T) {
 	require.Equal(t, v4, rl4.Get(k4))
 
 	// check commitInfo in storage
-	ci, err = store.getCommitInfoFromDb(2)
+	ci, err = store.GetCommitInfoFromDb(2)
 	require.NoError(t, err)
 	require.Equal(t, int64(2), ci.Version)
 	require.Equal(t, 4, len(ci.StoreInfos), ci.StoreInfos)
@@ -354,7 +354,7 @@ func TestMultiStoreRestart(t *testing.T) {
 
 		multi.Commit()
 
-		cinfo, err := multi.getCommitInfoFromDb(int64(i))
+		cinfo, err := multi.GetCommitInfoFromDb(int64(i))
 		require.NoError(t, err)
 		require.Equal(t, int64(i), cinfo.Version)
 	}
@@ -369,7 +369,7 @@ func TestMultiStoreRestart(t *testing.T) {
 
 	multi.Commit()
 
-	flushedCinfo, err := multi.getCommitInfoFromDb(3)
+	flushedCinfo, err := multi.GetCommitInfoFromDb(3)
 	require.Nil(t, err)
 	require.NotEqual(t, initCid, flushedCinfo, "CID is different after flush to disk")
 
@@ -379,7 +379,7 @@ func TestMultiStoreRestart(t *testing.T) {
 
 	multi.Commit()
 
-	postFlushCinfo, err := multi.getCommitInfoFromDb(4)
+	postFlushCinfo, err := multi.GetCommitInfoFromDb(4)
 	require.NoError(t, err)
 	require.Equal(t, int64(4), postFlushCinfo.Version, "Commit changed after in-memory commit")
 

--- a/store/types/store.go
+++ b/store/types/store.go
@@ -164,6 +164,9 @@ type CommitMultiStore interface {
 	// Panics on a nil key.
 	GetCommitKVStore(key StoreKey) CommitKVStore
 
+	// Panics on a nil key.
+	GetCommitInfoFromDb(ver int64) (*CommitInfo, error)
+
 	// Load the latest persisted version. Called once after all calls to
 	// Mount*Store() are complete.
 	LoadLatestVersion() error

--- a/store/types/store.go
+++ b/store/types/store.go
@@ -164,7 +164,7 @@ type CommitMultiStore interface {
 	// Panics on a nil key.
 	GetCommitKVStore(key StoreKey) CommitKVStore
 
-	// Panics on a nil key.
+	// Panics on a nil version.
 	GetCommitInfoFromDb(ver int64) (*CommitInfo, error)
 
 	// Load the latest persisted version. Called once after all calls to

--- a/store/types/store.go
+++ b/store/types/store.go
@@ -165,7 +165,7 @@ type CommitMultiStore interface {
 	GetCommitKVStore(key StoreKey) CommitKVStore
 
 	// Panics on a nil version.
-	GetCommitInfoFromDb(ver int64) (*CommitInfo, error)
+	GetCommitInfoFromDB(ver int64) (*CommitInfo, error)
 
 	// Load the latest persisted version. Called once after all calls to
 	// Mount*Store() are complete.

--- a/types/module/module_test.go
+++ b/types/module/module_test.go
@@ -239,7 +239,7 @@ func TestManager_ExportGenesis(t *testing.T) {
 	want := map[string]json.RawMessage{
 		"module1": json.RawMessage(`{"key1": "value1"}`),
 		"module2": json.RawMessage(`{"key2": "value2"}`)}
-	require.Equal(t, want, mm.ExportGenesisForModules(ctx, cdc, []string{}))
+	require.Equal(t, want, mm.ExportGenesis(ctx, cdc))
 }
 
 func TestManager_BeginBlock(t *testing.T) {

--- a/types/module/module_test.go
+++ b/types/module/module_test.go
@@ -239,7 +239,7 @@ func TestManager_ExportGenesis(t *testing.T) {
 	want := map[string]json.RawMessage{
 		"module1": json.RawMessage(`{"key1": "value1"}`),
 		"module2": json.RawMessage(`{"key2": "value2"}`)}
-	require.Equal(t, want, mm.ExportGenesis(ctx, cdc, []string{}))
+	require.Equal(t, want, mm.ExportGenesisForModules(ctx, cdc, []string{}))
 }
 
 func TestManager_BeginBlock(t *testing.T) {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: https://github.com/osmosis-labs/osmosis/issues/2952

## What is the purpose of the change

As requested by https://github.com/osmosis-labs/osmosis/issues/2952, this PR adds module hash query functionality to the store abci query endpoint.

Web endpoint shows base64 encoded:

http://localhost:26657/abci_query?path="store/info"&height=11

![Screen Shot 2022-10-06 at 10 01 13 AM](https://user-images.githubusercontent.com/40078083/194364039-ee4a828f-6bc4-439e-8e01-a6212d07c536.png)

Decode with the following command:

`curl -s 'http://localhost:26657/abci_query?path="store/info"&height=11' | jq -r '.result.response.value' | base64 -d;echo`

![Screen Shot 2022-10-06 at 10 04 17 AM](https://user-images.githubusercontent.com/40078083/194364195-bdfec2c2-95fd-42a5-ad69-0a935a9dd10b.png)



## Brief Changelog

- adds "info" path to "store"
- changes getCommitInfoFromDb to be public
- fixes module_test bug leftover from another PR


## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? yes
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable
