### PR TITLE
chore: backport support debug trace QueryResult (#11148)

### DIFF
--- a/types/errors/abci.go
+++ b/types/errors/abci.go
@@ -104,6 +104,18 @@ func QueryResult(err error) abci.ResponseQuery {
 	}
 }
 
+// QueryResultWithDebug returns a ResponseQuery from an error. It will try to parse ABCI
+// info from the error. It will use debugErrEncoder if debug parameter is true.
+// Starting from v0.46, this function will be removed, and be replaced by `QueryResult`.
+func QueryResultWithDebug(err error, debug bool) abci.ResponseQuery {
+	space, code, log := ABCIInfo(err, debug)
+	return abci.ResponseQuery{
+		Codespace: space,
+		Code:      code,
+		Log:       log,
+	}
+}
+
 // The debugErrEncoder encodes the error with a stacktrace.
 func debugErrEncoder(err error) string {
 	return fmt.Sprintf("%+v", err)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Backporting https://github.com/cosmos/cosmos-sdk/pull/11148 from v0.45.8

Other change I would like to backport related to missing return in ABCI query depends on this


## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable
