### PR TITLE
fix: Revert cache ctx change from SDK, move back into osmosis

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -78,3 +78,11 @@ pull_request_rules:
       backport:
         branches:
           - v12.x
+  - name: backport patches to v13.x branch
+    conditions:
+      - base=osmosis-main
+      - label=A:backport/v13.x
+    actions:
+      backport:
+        branches:
+          - v13.x

--- a/types/context.go
+++ b/types/context.go
@@ -269,7 +269,8 @@ func (c Context) CacheContext() (cc Context, writeCache func()) {
 	cc = c.WithMultiStore(cms).WithEventManager(NewEventManager())
 
 	writeCache = func() {
-		c.EventManager().EmitEvents(cc.EventManager().Events())
+		// commented out for compatability with SDK v0.45.10. Relayers depend on this
+		// c.EventManager().EmitEvents(cc.EventManager().Events())
 		cms.Write()
 	}
 


### PR DESCRIPTION
IBC uses cache ctx, and changes their event behavior, which other things listen onto