### PR TITLE
Start CacheKV store v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/confio/ics23/go v0.7.0
 	github.com/cosmos/btcutil v1.0.4
 	github.com/cosmos/go-bip39 v1.0.0
-	github.com/cosmos/iavl v0.19.4
+	github.com/cosmos/iavl v0.19.0
 	github.com/cosmos/ledger-cosmos-go v0.11.1
 	github.com/gogo/gateway v1.1.0
 	github.com/gogo/protobuf v1.3.3
@@ -44,6 +44,7 @@ require (
 	github.com/tendermint/go-amino v0.16.0
 	github.com/tendermint/tendermint v0.34.21
 	github.com/tendermint/tm-db v0.6.6
+	github.com/tidwall/btree v1.5.2
 	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e
 	google.golang.org/genproto v0.0.0-20220725144611-272f38e5d71b
 	google.golang.org/grpc v1.49.0

--- a/go.sum
+++ b/go.sum
@@ -162,8 +162,8 @@ github.com/cosmos/btcutil v1.0.4/go.mod h1:Ffqc8Hn6TJUdDgHBwIZLtrLQC1KdJ9jGJl/Tv
 github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d/go.mod h1:tSxLoYXyBmiFeKpvmq4dzayMdCjCnu8uqmCysIGBT2Y=
 github.com/cosmos/go-bip39 v1.0.0 h1:pcomnQdrdH22njcAatO0yWojsUnCO3y2tNoV1cb6hHY=
 github.com/cosmos/go-bip39 v1.0.0/go.mod h1:RNJv0H/pOIVgxw6KS7QeX2a0Uo0aKUlfhZ4xuwvCdJw=
-github.com/cosmos/iavl v0.19.4 h1:t82sN+Y0WeqxDLJRSpNd8YFX5URIrT+p8n6oJbJ2Dok=
-github.com/cosmos/iavl v0.19.4/go.mod h1:X9PKD3J0iFxdmgNLa7b2LYWdsGd90ToV5cAONApkEPw=
+github.com/cosmos/iavl v0.19.0 h1:sgyrjqOkycXiN7Tuupuo4QAldKFg7Sipyfeg/IL7cps=
+github.com/cosmos/iavl v0.19.0/go.mod h1:l5h9pAB3m5fihB3pXVgwYqdY8aBsMagqz7T0MUjxZeA=
 github.com/cosmos/keyring v1.1.7-0.20210622111912-ef00f8ac3d76 h1:DdzS1m6o/pCqeZ8VOAit/gyATedRgjvkVI+UCrLpyuU=
 github.com/cosmos/keyring v1.1.7-0.20210622111912-ef00f8ac3d76/go.mod h1:0mkLWIoZuQ7uBoospo5Q9zIpqq6rYCPJDSUdeCJvPM8=
 github.com/cosmos/ledger-cosmos-go v0.11.1 h1:9JIYsGnXP613pb2vPjFeMMjBI5lEDsEaF6oYorTy6J4=
@@ -767,6 +767,8 @@ github.com/tendermint/go-amino v0.16.0 h1:GyhmgQKvqF82e2oZeuMSp9JTN0N09emoSZlb2l
 github.com/tendermint/go-amino v0.16.0/go.mod h1:TQU0M1i/ImAo+tYpZi73AU3V/dKeCoMC9Sphe2ZwGME=
 github.com/tendermint/tendermint v0.34.21 h1:UiGGnBFHVrZhoQVQ7EfwSOLuCtarqCSsRf8VrklqB7s=
 github.com/tendermint/tendermint v0.34.21/go.mod h1:XDvfg6U7grcFTDx7VkzxnhazQ/bspGJAn4DZ6DcLLjQ=
+github.com/tidwall/btree v1.5.2 h1:5eA83Gfki799V3d3bJo9sWk+yL2LRoTEah3O/SA6/8w=
+github.com/tidwall/btree v1.5.2/go.mod h1:twD9XRA5jj9VUQGELzDO4HPQTNJsoWWfYEL+EUQ2cKY=
 github.com/tidwall/gjson v1.6.7/go.mod h1:zeFuBCIqD4sN/gmqBzZ4j7Jd6UcA2Fc56x7QFsv+8fI=
 github.com/tidwall/match v1.0.3/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
 github.com/tidwall/pretty v1.0.2/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=

--- a/store/cachekv2/README.md
+++ b/store/cachekv2/README.md
@@ -1,0 +1,27 @@
+# CacheKV
+
+A `CacheKVStore` is cache wrapper for a `KVStore`. It extends the operations of the `KVStore` to work with a cache, allowing for reduced I/O operations and more efficient disposing of changes (e.g. after processing a failed transaction).
+
+The core goals the CacheKVStore seeks to solve are:
+
+* Buffer all writes to the parent store, so they can be dropped if they needs to be reverted
+* Allow iteration over contiguous spans of keys (all SDK stores)
+* Act as a cache, so we don't repeat I/O to disk for reads we've already done
+* Make subsequent reads, account for prior buffered writes
+* Write all changes to the parent store
+
+We build this as two stores, one for "dirty write storage", and a second for read caching.
+We then make a default constructor that creates both.
+
+## Intended later changes
+
+API breaks are needed for these, but would like:
+
+* Express separate cache retention policies for:
+    * One-off read caching (e.g. only LRU cache for 1000 entries)
+    * Iterator interval read caching
+* Charging a separate gas amount for a read in cache vs not in cache.
+
+An SDK design choice that should happen is:
+
+* BeginBlock and EndBlock should not have the write buffer enabled, and should use a different cache for minimal LRU's on reads.

--- a/store/cachekv2/README.md
+++ b/store/cachekv2/README.md
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 # CacheKV
 
 A `CacheKVStore` is cache wrapper for a `KVStore`. It extends the operations of the `KVStore` to work with a cache, allowing for reduced I/O operations and more efficient disposing of changes (e.g. after processing a failed transaction).
@@ -37,3 +38,45 @@ More API breaks are needed for these, but would like:
 An SDK design choice that should happen is:
 
 * BeginBlock and EndBlock should not have the write buffer enabled, and should use a different cache for minimal LRU's on reads
+||||||| parent of e92c96245b (let me change files...)
+=======
+# CacheKV
+
+A `CacheKVStore` is cache wrapper for a `KVStore`. It extends the operations of the `KVStore` to work with a cache, allowing for reduced I/O operations and more efficient disposing of changes (e.g. after processing a failed transaction).
+
+The core goals the CacheKVStore seeks to solve are:
+
+* Buffer all writes to the parent store, so they can be dropped if they needs to be reverted
+* Allow iteration over contiguous spans of keys (all SDK stores)
+* Act as a cache, so we don't repeat I/O to disk for reads we've already done
+* Make subsequent reads, account for prior buffered writes
+* Write all changes to the parent store
+
+We build this as two stores, one for "dirty write storage", and a second for read caching.
+We then make a default constructor that creates both.
+
+This is NOT compatible with CacheKV store v1, or the existing store semantics.
+This is because the current design of the SDK allows for (and actively abuses) iterator invalidation,
+which leads to a slew of single-threaded concurrency issues.
+(This is in fact the straw that broke the camel's back triggering this rewrite)
+
+Issues are that namely during iterator creation you can:
+
+* Always mutate what your iterating over (no iter_mut vs iter separation, and anywhere in range)
+* Delete your current entry during an iterator call (because theres no DeleteRange API)
+* New writes & deletes (even into the range your iterating over), that just don't get added into your iterator
+    * The way this is designed, can also lead to deadlocks / result incorrectness if multiple iterators exist in parallel
+
+## Intended later changes
+
+More API breaks are needed for these, but would like:
+
+* Express separate cache retention policies for:
+    * One-off read caching (e.g. only LRU cache for 1000 entries)
+    * Iterator interval read caching
+* Charging a separate gas amount for a read in cache vs not in cache.
+
+An SDK design choice that should happen is:
+
+* BeginBlock and EndBlock should not have the write buffer enabled, and should use a different cache for minimal LRU's on reads
+>>>>>>> e92c96245b (let me change files...)

--- a/store/cachekv2/STATE_MODEL.md
+++ b/store/cachekv2/STATE_MODEL.md
@@ -1,0 +1,18 @@
+# State model
+
+The existing SDK state model is broken with regard to whats the role of iterators.
+We propose the mental model to be that every "Store" call be a claim on a collection (range) of data.
+There can be multiple concurrent "read" claims on a range at a time.
+There may only be one open "write" claim on a range, and if there are any open write claims then there can be no other read claims.
+
+## Motivation
+
+Right now the mental model of state is that it is one (massive) Key-Value map per module.
+When you get a store, you are claiming read-write access over it. (either the whole module, or some range in the case of a prefix store)
+
+We currently buffer all writes to this module in a "CacheKV store".
+But our model for dealing with these writes is quite unsafe & unspecified.
+You can have many readers and writers to the same data in parallel.
+Each iterator-reader reads the state of the data at time of reader-open, despite whatever its call trace may do.
+You may also want to write somewhere outside of this range in the store.
+This should in principle be fine, however it is not right now.

--- a/store/cachekv2/mergeiterator.go
+++ b/store/cachekv2/mergeiterator.go
@@ -1,0 +1,251 @@
+package cachekv
+
+import (
+	"bytes"
+	"errors"
+
+	"github.com/cosmos/cosmos-sdk/store/types"
+)
+
+// cacheMergeIterator merges a parent Iterator and a cache Iterator.
+// The cache iterator may return nil keys to signal that an item
+// had been deleted (but not deleted in the parent).
+// If the cache iterator has the same key as the parent, the
+// cache shadows (overrides) the parent.
+//
+// TODO: Optimize by memoizing.
+type cacheMergeIterator struct {
+	parent    types.Iterator
+	cache     types.Iterator
+	ascending bool
+}
+
+var _ types.Iterator = (*cacheMergeIterator)(nil)
+
+func newCacheMergeIterator(parent, cache types.Iterator, ascending bool) *cacheMergeIterator {
+	iter := &cacheMergeIterator{
+		parent:    parent,
+		cache:     cache,
+		ascending: ascending,
+	}
+
+	return iter
+}
+
+// Domain implements Iterator.
+// If the domains are different, returns the union.
+func (iter *cacheMergeIterator) Domain() (start, end []byte) {
+	startP, endP := iter.parent.Domain()
+	startC, endC := iter.cache.Domain()
+
+	if iter.compare(startP, startC) < 0 {
+		start = startP
+	} else {
+		start = startC
+	}
+
+	if iter.compare(endP, endC) < 0 {
+		end = endC
+	} else {
+		end = endP
+	}
+
+	return start, end
+}
+
+// Valid implements Iterator.
+func (iter *cacheMergeIterator) Valid() bool {
+	return iter.skipUntilExistsOrInvalid()
+}
+
+// Next implements Iterator
+func (iter *cacheMergeIterator) Next() {
+	iter.skipUntilExistsOrInvalid()
+	iter.assertValid()
+
+	// If parent is invalid, get the next cache item.
+	if !iter.parent.Valid() {
+		iter.cache.Next()
+		return
+	}
+
+	// If cache is invalid, get the next parent item.
+	if !iter.cache.Valid() {
+		iter.parent.Next()
+		return
+	}
+
+	// Both are valid.  Compare keys.
+	keyP, keyC := iter.parent.Key(), iter.cache.Key()
+	switch iter.compare(keyP, keyC) {
+	case -1: // parent < cache
+		iter.parent.Next()
+	case 0: // parent == cache
+		iter.parent.Next()
+		iter.cache.Next()
+	case 1: // parent > cache
+		iter.cache.Next()
+	}
+}
+
+// Key implements Iterator
+func (iter *cacheMergeIterator) Key() []byte {
+	iter.skipUntilExistsOrInvalid()
+	iter.assertValid()
+
+	// If parent is invalid, get the cache key.
+	if !iter.parent.Valid() {
+		return iter.cache.Key()
+	}
+
+	// If cache is invalid, get the parent key.
+	if !iter.cache.Valid() {
+		return iter.parent.Key()
+	}
+
+	// Both are valid.  Compare keys.
+	keyP, keyC := iter.parent.Key(), iter.cache.Key()
+
+	cmp := iter.compare(keyP, keyC)
+	switch cmp {
+	case -1: // parent < cache
+		return keyP
+	case 0: // parent == cache
+		return keyP
+	case 1: // parent > cache
+		return keyC
+	default:
+		panic("invalid compare result")
+	}
+}
+
+// Value implements Iterator
+func (iter *cacheMergeIterator) Value() []byte {
+	iter.skipUntilExistsOrInvalid()
+	iter.assertValid()
+
+	// If parent is invalid, get the cache value.
+	if !iter.parent.Valid() {
+		return iter.cache.Value()
+	}
+
+	// If cache is invalid, get the parent value.
+	if !iter.cache.Valid() {
+		return iter.parent.Value()
+	}
+
+	// Both are valid.  Compare keys.
+	keyP, keyC := iter.parent.Key(), iter.cache.Key()
+
+	cmp := iter.compare(keyP, keyC)
+	switch cmp {
+	case -1: // parent < cache
+		return iter.parent.Value()
+	case 0: // parent == cache
+		return iter.cache.Value()
+	case 1: // parent > cache
+		return iter.cache.Value()
+	default:
+		panic("invalid comparison result")
+	}
+}
+
+// Close implements Iterator
+func (iter *cacheMergeIterator) Close() error {
+	if err := iter.parent.Close(); err != nil {
+		return err
+	}
+
+	return iter.cache.Close()
+}
+
+// Error returns an error if the cacheMergeIterator is invalid defined by the
+// Valid method.
+func (iter *cacheMergeIterator) Error() error {
+	if !iter.Valid() {
+		return errors.New("invalid cacheMergeIterator")
+	}
+
+	return nil
+}
+
+// If not valid, panics.
+// NOTE: May have side-effect of iterating over cache.
+func (iter *cacheMergeIterator) assertValid() {
+	if err := iter.Error(); err != nil {
+		panic(err)
+	}
+}
+
+// Like bytes.Compare but opposite if not ascending.
+func (iter *cacheMergeIterator) compare(a, b []byte) int {
+	compRes := bytes.Compare(a, b)
+	if iter.ascending {
+		return compRes
+	}
+	return compRes * -1
+}
+
+// Skip all delete-items from the cache w/ `key < until`.  After this function,
+// current cache item is a non-delete-item, or `until <= key`.
+// If the current cache item is not a delete item, does nothing.
+// If `until` is nil, there is no limit, and cache may end up invalid.
+// CONTRACT: cache is valid.
+func (iter *cacheMergeIterator) skipCacheDeletes(until []byte) {
+	for iter.cache.Valid() &&
+		iter.cache.Value() == nil &&
+		(until == nil || iter.compare(iter.cache.Key(), until) < 0) {
+		iter.cache.Next()
+	}
+}
+
+// Fast forwards cache (or parent+cache in case of deleted items) until current
+// item exists, or until iterator becomes invalid.
+// Returns whether the iterator is valid.
+func (iter *cacheMergeIterator) skipUntilExistsOrInvalid() bool {
+	for {
+		// If parent is invalid, fast-forward cache.
+		if !iter.parent.Valid() {
+			iter.skipCacheDeletes(nil)
+			return iter.cache.Valid()
+		}
+		// Parent is valid.
+
+		if !iter.cache.Valid() {
+			return true
+		}
+		// Parent is valid, cache is valid.
+
+		// Compare parent and cache.
+		keyP := iter.parent.Key()
+		keyC := iter.cache.Key()
+
+		switch iter.compare(keyP, keyC) {
+		case -1: // parent < cache.
+			return true
+
+		case 0: // parent == cache.
+			// Skip over if cache item is a delete.
+			valueC := iter.cache.Value()
+			if valueC == nil {
+				iter.parent.Next()
+				iter.cache.Next()
+
+				continue
+			}
+			// Cache is not a delete.
+
+			return true // cache exists.
+		case 1: // cache < parent
+			// Skip over if cache item is a delete.
+			valueC := iter.cache.Value()
+			if valueC == nil {
+				iter.skipCacheDeletes(keyP)
+				continue
+			}
+			// Cache is not a delete.
+
+			return true // cache exists.
+		}
+	}
+}

--- a/store/cachekv2/writebuffer/README.md
+++ b/store/cachekv2/writebuffer/README.md
@@ -1,5 +1,15 @@
 # Write Buffer
 
-Write buffer is naive.
-Dead simple, map with a mutex for storing all edits within the height.
-Only unit of complexity is iterations.
+This module implements a simple write buffer, satisfying the current cosmos iteration API.
+We make a btree map of KV pairs that we write to.
+All reads are reads off the write buffer, this has no notion of parents.
+
+There are no mutexes here, its up to a caller to set concurrency guidelines.
+The API for reads and writes here, use `key` represented as a string.
+
+## Restrictions
+
+No new store writes are allowed while any iterator is open.
+(TODO: We need to relax this. TBD of do we this via data structure change, changing our iterator to know if a write happened and re-seek, etc. Common use cases to allow: Updating key being iterated on, e.g. `vec.itermut()`, or deleting a range of keys. (Dumb that we use this API for it, maybe we change that))
+
+TODO for future applications, investigate making tidwall/btree preserve allocated RAM on `Clear()`.

--- a/store/cachekv2/writebuffer/README.md
+++ b/store/cachekv2/writebuffer/README.md
@@ -1,0 +1,5 @@
+# Write Buffer
+
+Write buffer is naive.
+Dead simple, map with a mutex for storing all edits within the height.
+Only unit of complexity is iterations.

--- a/store/cachekv2/writebuffer/writebuffer.go
+++ b/store/cachekv2/writebuffer/writebuffer.go
@@ -1,0 +1,118 @@
+package cachekv
+
+import (
+	"time"
+
+	"github.com/tidwall/btree"
+
+	"github.com/cosmos/cosmos-sdk/store/types"
+	"github.com/cosmos/cosmos-sdk/telemetry"
+)
+
+// Store wraps an in-memory cache around an underlying types.KVStore.
+type Store struct {
+	// this is a map from key -> value, string -> []byte
+	// if value is nil, means its deleted.
+	bufferedWrites *btree.Map[string, []byte]
+	parent         types.KVStore
+}
+
+// NewStore creates a new Store object
+func NewStore(parent types.KVStore) *Store {
+	return &Store{
+		bufferedWrites: btree.NewMap[string, []byte](16),
+		parent:         parent,
+	}
+}
+
+// GetStoreType implements Store.
+func (store *Store) GetStoreType() types.StoreType {
+	return store.parent.GetStoreType()
+}
+
+func (store *Store) GetString(key string) (value []byte) {
+	value, _ = store.bufferedWrites.Get(key)
+	return value
+}
+
+func (store *Store) SetString(key string, value []byte) {
+	store.bufferedWrites.Set(key, value)
+}
+
+func (store *Store) HasString(key string) bool {
+	_, found := store.bufferedWrites.Get(key)
+	return found
+}
+
+func (store *Store) DeleteString(key string) {
+	store.bufferedWrites.Delete(key)
+}
+
+// Implements Cachetypes.KVStore.
+func (store *Store) Write() {
+	defer telemetry.MeasureSince(time.Now(), "store", "cachekv", "write")
+
+	// TODO: Consider allowing usage of Batch, which would allow the write to
+	// at least happen atomically.
+	store.bufferedWrites.Ascend("", func(key string, value []byte) bool {
+		if value == nil {
+			// We use []byte(key) instead of conv.UnsafeStrToBytes because we cannot
+			// be sure if the underlying store might do a save with the byteslice or
+			// not. Once we get confirmation that .Delete is guaranteed not to
+			// save the byteslice, then we can assume only a read-only copy is sufficient.
+			store.parent.Delete([]byte(key))
+			return false
+		}
+		// It already exists in the parent, hence delete it.
+		store.parent.Set([]byte(key), value)
+		return false
+	})
+
+	// TODO: Investigate getting better memory re-use in this.
+	// Its a waste that we have to go re-allocate everything later :(
+	store.bufferedWrites.Clear()
+}
+
+//----------------------------------------
+// Iteration
+
+// Iterator implements types.KVStore.
+func (store *Store) Iterator(start, end []byte) types.Iterator {
+	var a types.Iterator
+	return a
+}
+
+// ReverseIterator implements types.KVStore.
+func (store *Store) ReverseIterator(start, end []byte) types.Iterator {
+	var a types.Iterator
+	return a
+}
+
+// func (store *Store) iterator(start, end []byte, ascending bool) types.Iterator {
+// 	expectedId := nextIteratorId
+// 	fmt.Printf("calling lock for iterator creation, cur next id %v\n", expectedId)
+// 	fmt.Printf("current store mtx address %p\n", &store.mtx)
+// 	fmt.Printf("current memdb address %p\n", store.sortedCache)
+// 	store.mtx.Lock()
+// 	defer store.mtx.Unlock()
+// 	fmt.Printf("got past iterator lock with expected id %v, next iterator id %v\n", expectedId, nextIteratorId)
+
+// 	var parent, cache types.Iterator
+
+// 	fmt.Println("Creating a parent iterator")
+// 	if ascending {
+// 		parent = store.parent.Iterator(start, end)
+// 	} else {
+// 		parent = store.parent.ReverseIterator(start, end)
+// 	}
+// 	fmt.Println("Finished creating a parent iterator")
+
+// 	store.dirtyItems(start, end)
+
+// 	fmt.Println("Creating a mem iterator")
+// 	cache = newMemIterator(start, end, store.sortedCache, store.deleted, ascending)
+// 	fmt.Println("Finished creating a mem iterator")
+
+// 	iter := newCacheMergeIterator(parent, cache, ascending)
+// 	return iter
+// }

--- a/store/cachekv2/writebuffer/writebuffer.go
+++ b/store/cachekv2/writebuffer/writebuffer.go
@@ -10,109 +10,73 @@ import (
 )
 
 // Store wraps an in-memory cache around an underlying types.KVStore.
-type Store struct {
+type WriteBuffer struct {
 	// this is a map from key -> value, string -> []byte
 	// if value is nil, means its deleted.
-	bufferedWrites *btree.Map[string, []byte]
-	parent         types.KVStore
+	buffer *btree.Map[string, []byte]
 }
 
 // NewStore creates a new Store object
-func NewStore(parent types.KVStore) *Store {
-	return &Store{
-		bufferedWrites: btree.NewMap[string, []byte](16),
-		parent:         parent,
+func NewWriteBuffer() *WriteBuffer {
+	return &WriteBuffer{
+		buffer: btree.NewMap[string, []byte](16),
 	}
 }
 
-// GetStoreType implements Store.
-func (store *Store) GetStoreType() types.StoreType {
-	return store.parent.GetStoreType()
+func (wb *WriteBuffer) GetString(key string) (value []byte, found bool) {
+	value, found = wb.bufferedWrites.Get(key)
+	return value, found
 }
 
-func (store *Store) GetString(key string) (value []byte) {
-	value, _ = store.bufferedWrites.Get(key)
-	return value
+func (wb *WriteBuffer) SetString(key string, value []byte) {
+	wb.buffer.Set(key, value)
 }
 
-func (store *Store) SetString(key string, value []byte) {
-	store.bufferedWrites.Set(key, value)
-}
-
-func (store *Store) HasString(key string) bool {
-	_, found := store.bufferedWrites.Get(key)
+func (wb *WriteBuffer) HasString(key string) bool {
+	_, found := wb.buffer.Get(key)
 	return found
 }
 
-func (store *Store) DeleteString(key string) {
-	store.bufferedWrites.Delete(key)
+func (wb *WriteBuffer) DeleteString(key string) {
+	wb.buffer.Delete(key)
 }
 
 // Implements Cachetypes.KVStore.
-func (store *Store) Write() {
-	defer telemetry.MeasureSince(time.Now(), "store", "cachekv", "write")
+func (wb *WriteBuffer) WriteTo(parent types.KVStore) {
+	defer telemetry.MeasureSince(time.Now(), "store", "WriteBuffer", "write")
 
 	// TODO: Consider allowing usage of Batch, which would allow the write to
 	// at least happen atomically.
-	store.bufferedWrites.Ascend("", func(key string, value []byte) bool {
+	wb.buffer.Ascend("", func(key string, value []byte) bool {
 		if value == nil {
 			// We use []byte(key) instead of conv.UnsafeStrToBytes because we cannot
 			// be sure if the underlying store might do a save with the byteslice or
 			// not. Once we get confirmation that .Delete is guaranteed not to
 			// save the byteslice, then we can assume only a read-only copy is sufficient.
-			store.parent.Delete([]byte(key))
+			parent.Delete([]byte(key))
 			return false
 		}
 		// It already exists in the parent, hence delete it.
-		store.parent.Set([]byte(key), value)
+		parent.Set([]byte(key), value)
 		return false
 	})
 
 	// TODO: Investigate getting better memory re-use in this.
 	// Its a waste that we have to go re-allocate everything later :(
-	store.bufferedWrites.Clear()
+	wb.buffer.Clear()
 }
 
 //----------------------------------------
 // Iteration
 
 // Iterator implements types.KVStore.
-func (store *Store) Iterator(start, end []byte) types.Iterator {
+func (wb *WriteBuffer) Iterator(start, end []byte) types.Iterator {
 	var a types.Iterator
 	return a
 }
 
 // ReverseIterator implements types.KVStore.
-func (store *Store) ReverseIterator(start, end []byte) types.Iterator {
+func (wb *WriteBuffer) ReverseIterator(start, end []byte) types.Iterator {
 	var a types.Iterator
 	return a
 }
-
-// func (store *Store) iterator(start, end []byte, ascending bool) types.Iterator {
-// 	expectedId := nextIteratorId
-// 	fmt.Printf("calling lock for iterator creation, cur next id %v\n", expectedId)
-// 	fmt.Printf("current store mtx address %p\n", &store.mtx)
-// 	fmt.Printf("current memdb address %p\n", store.sortedCache)
-// 	store.mtx.Lock()
-// 	defer store.mtx.Unlock()
-// 	fmt.Printf("got past iterator lock with expected id %v, next iterator id %v\n", expectedId, nextIteratorId)
-
-// 	var parent, cache types.Iterator
-
-// 	fmt.Println("Creating a parent iterator")
-// 	if ascending {
-// 		parent = store.parent.Iterator(start, end)
-// 	} else {
-// 		parent = store.parent.ReverseIterator(start, end)
-// 	}
-// 	fmt.Println("Finished creating a parent iterator")
-
-// 	store.dirtyItems(start, end)
-
-// 	fmt.Println("Creating a mem iterator")
-// 	cache = newMemIterator(start, end, store.sortedCache, store.deleted, ascending)
-// 	fmt.Println("Finished creating a mem iterator")
-
-// 	iter := newCacheMergeIterator(parent, cache, ascending)
-// 	return iter
-// }

--- a/store/cachekv2/writebuffer/writebuffer.go
+++ b/store/cachekv2/writebuffer/writebuffer.go
@@ -69,6 +69,10 @@ func (wb *WriteBuffer) WriteTo(parent types.KVStore) {
 //----------------------------------------
 // Iteration
 
+//
+type wbIterator struct {
+}
+
 // Iterator implements types.KVStore.
 func (wb *WriteBuffer) Iterator(start, end []byte) types.Iterator {
 	var a types.Iterator

--- a/store/iavl/store.go
+++ b/store/iavl/store.go
@@ -53,7 +53,7 @@ func LoadStore(db dbm.DB, logger log.Logger, key types.StoreKey, id types.Commit
 // provided DB. An error is returned if the version fails to load, or if called with a positive
 // version on an empty tree.
 func LoadStoreWithInitialVersion(db dbm.DB, logger log.Logger, key types.StoreKey, id types.CommitID, lazyLoading bool, initialVersion uint64, cacheSize int) (types.CommitKVStore, error) {
-	tree, err := iavl.NewMutableTreeWithOpts(db, cacheSize, &iavl.Options{InitialVersion: initialVersion}, false)
+	tree, err := iavl.NewMutableTreeWithOpts(db, cacheSize, &iavl.Options{InitialVersion: initialVersion})
 	if err != nil {
 		return nil, err
 	}

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -48,6 +48,8 @@ type storeParams struct {
 	initialVersion uint64
 }
 
+var _ types.CacheWrapper = types.CommitKVStore
+
 // Store is composed of many CommitStores. Name contrasts with
 // cacheMultiStore which is used for branching other MultiStores. It implements
 // the CommitMultiStore interface.

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -48,8 +48,6 @@ type storeParams struct {
 	initialVersion uint64
 }
 
-var _ types.CacheWrapper = types.CommitKVStore
-
 // Store is composed of many CommitStores. Name contrasts with
 // cacheMultiStore which is used for branching other MultiStores. It implements
 // the CommitMultiStore interface.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Start CacheKV store v2, that separates responsibilities, cleans up code significantly.

Should eliminate dead lock risks, and significantly improve performance.

TY to @dangush  for helpful discussions around spec leading to this. (Feel free to help contribute with this!)

The architecture of this is based on separating the roles of whats going on.

We acknowledge that the cache kv store has two responsibilities, and explicitly make two different internal structs and compose them together. Responsibilities
- WriteBuffer
- ReadCache

This lets us re-use and improve each component independently, keeps each component pretty simple, and advance the clear API breaking roadmaps for improvement for each. (And joint performance measurement / improvement remains pretty simple)

## Current status

Base write buffer written, need to add iterator.

Barely any docs

## Brief Changelog

*(for example:)*
 
  - *The metadata is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *Daemons retrieve the RPC data from the blob cache*


## Testing and Verifying

*(Please pick one of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added unit test that validates ...*
  - *Added integration tests for end-to-end deployment with ...*
  - *Extended integration test for ...*
  - *Manually verified the change by ...*

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)
