### PR TITLE
fix: comment in app.toml

### DIFF
--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -177,7 +177,7 @@ enable = {{ .GRPC.Enable }}
 address = "{{ .GRPC.Address }}"
 
 # MaxRecvMsgSize defines the max message size in bytes the server can receive.
-# The default value is 4MB.
+# The default value is 10MB.
 max-recv-msg-size = "{{ .GRPC.MaxRecvMsgSize }}"
 
 # MaxSendMsgSize defines the max message size in bytes the server can send.


### PR DESCRIPTION
## What is the purpose of the change

small fix to comment in `app.toml`

## Brief Changelog

update a comment to reflect the default grpc `max-recv-msg-size` of 10MB

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? ( no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (no)
  - How is the feature or change documented? (not applicable)