### PR TITLE
feat: Add `TrackBeforeSend` , `BlockBeforeSend` hooks. Deprecate `BeforeSend` hook

### DIFF
--- a/x/bank/keeper/hooks.go
+++ b/x/bank/keeper/hooks.go
@@ -8,10 +8,17 @@ import (
 // Implements StakingHooks interface
 var _ types.BankHooks = BaseSendKeeper{}
 
-// BeforeSend executes the BeforeSend hook if registered.
-func (k BaseSendKeeper) BeforeSend(ctx sdk.Context, from, to sdk.AccAddress, amount sdk.Coins) error {
+// TrackbeforeSend executes the TrackBeforeSend hook if registered.
+func (k BaseSendKeeper) TrackBeforeSend(ctx sdk.Context, from, to sdk.AccAddress, amount sdk.Coins) {
 	if k.hooks != nil {
-		return k.hooks.BeforeSend(ctx, from, to, amount)
+		k.hooks.TrackBeforeSend(ctx, from, to, amount)
+	}
+}
+
+// BlockBeforeSend executes the BlockBeforeSend hook if registered.
+func (k BaseSendKeeper) BlockBeforeSend(ctx sdk.Context, from, to sdk.AccAddress, amount sdk.Coins) error {
+	if k.hooks != nil {
+		return k.hooks.BlockBeforeSend(ctx, from, to, amount)
 	}
 	return nil
 }

--- a/x/bank/keeper/hooks.go
+++ b/x/bank/keeper/hooks.go
@@ -8,7 +8,7 @@ import (
 // Implements StakingHooks interface
 var _ types.BankHooks = BaseSendKeeper{}
 
-// TrackbeforeSend executes the TrackBeforeSend hook if registered.
+// TrackBeforeSend executes the TrackBeforeSend hook if registered.
 func (k BaseSendKeeper) TrackBeforeSend(ctx sdk.Context, from, to sdk.AccAddress, amount sdk.Coins) {
 	if k.hooks != nil {
 		k.hooks.TrackBeforeSend(ctx, from, to, amount)

--- a/x/bank/keeper/hooks_test.go
+++ b/x/bank/keeper/hooks_test.go
@@ -20,15 +20,29 @@ var _ types.BankHooks = &MockBankHooksReceiver{}
 // BankHooks event hooks for bank (noalias)
 type MockBankHooksReceiver struct{}
 
-// Mock BeforeSend bank hook that doesn't allow the sending of exactly 100 coins of any denom.
-func (h *MockBankHooksReceiver) BeforeSend(ctx sdk.Context, from, to sdk.AccAddress, amount sdk.Coins) error {
+// Mock BlockBeforeSend bank hook that doesn't allow the sending of exactly 100 coins of any denom.
+func (h *MockBankHooksReceiver) BlockBeforeSend(ctx sdk.Context, from, to sdk.AccAddress, amount sdk.Coins) error {
 	for _, coin := range amount {
 		if coin.Amount.Equal(sdk.NewInt(100)) {
 			return fmt.Errorf("not allowed; expected %v, got: %v", 100, coin.Amount)
 		}
 	}
-
 	return nil
+}
+
+// variable for counting `TrackBeforeSend`
+var (
+	countTrackBeforeSend = 0
+	expNextCount         = 1
+)
+
+// Mock TrackBeforeSend bank hook that simply tracks the sending of exactly 50 coins of any denom.
+func (h *MockBankHooksReceiver) TrackBeforeSend(ctx sdk.Context, from, to sdk.AccAddress, amount sdk.Coins) {
+	for _, coin := range amount {
+		if coin.Amount.Equal(sdk.NewInt(50)) {
+			countTrackBeforeSend += 1
+		}
+	}
 }
 
 func TestHooks(t *testing.T) {
@@ -40,7 +54,8 @@ func TestHooks(t *testing.T) {
 
 	// create a valid send amount which is 1 coin, and an invalidSendAmount which is 100 coins
 	validSendAmount := sdk.NewCoins(sdk.NewCoin(app.StakingKeeper.BondDenom(ctx), sdk.NewInt(1)))
-	invalidSendAmount := sdk.NewCoins(sdk.NewCoin(app.StakingKeeper.BondDenom(ctx), sdk.NewInt(100)))
+	triggerTrackSendAmount := sdk.NewCoins(sdk.NewCoin(app.StakingKeeper.BondDenom(ctx), sdk.NewInt(50)))
+	invalidBlockSendAmount := sdk.NewCoins(sdk.NewCoin(app.StakingKeeper.BondDenom(ctx), sdk.NewInt(100)))
 
 	// setup our mock bank hooks receiver that prevents the send of 100 coins
 	bankHooksReceiver := MockBankHooksReceiver{}
@@ -55,47 +70,78 @@ func TestHooks(t *testing.T) {
 	err := app.BankKeeper.SendCoins(ctx, addrs[0], addrs[1], validSendAmount)
 	require.NoError(t, err)
 
+	// try sending an trigger track send amount and it should work
+	err = app.BankKeeper.SendCoins(ctx, addrs[0], addrs[1], triggerTrackSendAmount)
+	require.NoError(t, err)
+
+	require.Equal(t, countTrackBeforeSend, expNextCount)
+	expNextCount++
+
 	// try sending an invalidSendAmount and it should not work
-	err = app.BankKeeper.SendCoins(ctx, addrs[0], addrs[1], invalidSendAmount)
+	err = app.BankKeeper.SendCoins(ctx, addrs[0], addrs[1], invalidBlockSendAmount)
 	require.Error(t, err)
 
 	// try doing SendManyCoins and make sure if even a single subsend is invalid, the entire function fails
-	err = app.BankKeeper.SendManyCoins(ctx, addrs[0], []sdk.AccAddress{addrs[0], addrs[1]}, []sdk.Coins{invalidSendAmount, validSendAmount})
+	err = app.BankKeeper.SendManyCoins(ctx, addrs[0], []sdk.AccAddress{addrs[0], addrs[1]}, []sdk.Coins{invalidBlockSendAmount, validSendAmount})
 	require.Error(t, err)
+
+	err = app.BankKeeper.SendManyCoins(ctx, addrs[0], []sdk.AccAddress{addrs[0], addrs[1]}, []sdk.Coins{triggerTrackSendAmount, validSendAmount})
+	require.Equal(t, countTrackBeforeSend, expNextCount)
+	expNextCount++
 
 	// make sure that account to module doesn't bypass hook
 	err = app.BankKeeper.SendCoinsFromAccountToModule(ctx, addrs[0], stakingtypes.BondedPoolName, validSendAmount)
 	require.NoError(t, err)
-	err = app.BankKeeper.SendCoinsFromAccountToModule(ctx, addrs[0], stakingtypes.BondedPoolName, invalidSendAmount)
+	err = app.BankKeeper.SendCoinsFromAccountToModule(ctx, addrs[0], stakingtypes.BondedPoolName, invalidBlockSendAmount)
 	require.Error(t, err)
+	err = app.BankKeeper.SendCoinsFromAccountToModule(ctx, addrs[0], stakingtypes.BondedPoolName, triggerTrackSendAmount)
+	require.Equal(t, countTrackBeforeSend, expNextCount)
+	expNextCount++
 
 	// make sure that module to account doesn't bypass hook
 	err = app.BankKeeper.SendCoinsFromModuleToAccount(ctx, stakingtypes.BondedPoolName, addrs[0], validSendAmount)
 	require.NoError(t, err)
-	err = app.BankKeeper.SendCoinsFromModuleToAccount(ctx, stakingtypes.BondedPoolName, addrs[0], invalidSendAmount)
+	err = app.BankKeeper.SendCoinsFromModuleToAccount(ctx, stakingtypes.BondedPoolName, addrs[0], invalidBlockSendAmount)
 	require.Error(t, err)
+	err = app.BankKeeper.SendCoinsFromModuleToAccount(ctx, stakingtypes.BondedPoolName, addrs[0], triggerTrackSendAmount)
+	require.Equal(t, countTrackBeforeSend, expNextCount)
+	expNextCount++
 
 	// make sure that module to module doesn't bypass hook
 	err = app.BankKeeper.SendCoinsFromModuleToModule(ctx, stakingtypes.BondedPoolName, stakingtypes.NotBondedPoolName, validSendAmount)
 	require.NoError(t, err)
-	err = app.BankKeeper.SendCoinsFromModuleToModule(ctx, stakingtypes.BondedPoolName, stakingtypes.NotBondedPoolName, invalidSendAmount)
-	require.Error(t, err)
+	err = app.BankKeeper.SendCoinsFromModuleToModule(ctx, stakingtypes.BondedPoolName, stakingtypes.NotBondedPoolName, invalidBlockSendAmount)
+	// there should be no error since module to module does not call block before send hooks
+	require.NoError(t, err)
+	err = app.BankKeeper.SendCoinsFromModuleToModule(ctx, stakingtypes.BondedPoolName, stakingtypes.NotBondedPoolName, triggerTrackSendAmount)
+	require.Equal(t, countTrackBeforeSend, expNextCount)
+	expNextCount++
 
 	// make sure that module to many accounts doesn't bypass hook
 	err = app.BankKeeper.SendCoinsFromModuleToManyAccounts(ctx, stakingtypes.BondedPoolName, []sdk.AccAddress{addrs[0], addrs[1]}, []sdk.Coins{validSendAmount, validSendAmount})
 	require.NoError(t, err)
-	err = app.BankKeeper.SendCoinsFromModuleToManyAccounts(ctx, stakingtypes.BondedPoolName, []sdk.AccAddress{addrs[0], addrs[1]}, []sdk.Coins{validSendAmount, invalidSendAmount})
+	err = app.BankKeeper.SendCoinsFromModuleToManyAccounts(ctx, stakingtypes.BondedPoolName, []sdk.AccAddress{addrs[0], addrs[1]}, []sdk.Coins{validSendAmount, invalidBlockSendAmount})
 	require.Error(t, err)
+	err = app.BankKeeper.SendCoinsFromModuleToManyAccounts(ctx, stakingtypes.BondedPoolName, []sdk.AccAddress{addrs[0], addrs[1]}, []sdk.Coins{validSendAmount, triggerTrackSendAmount})
+	require.Equal(t, countTrackBeforeSend, expNextCount)
+	expNextCount++
 
 	// make sure that DelegateCoins doesn't bypass the hook
 	err = app.BankKeeper.DelegateCoins(ctx, addrs[0], app.AccountKeeper.GetModuleAddress(stakingtypes.BondedPoolName), validSendAmount)
 	require.NoError(t, err)
-	err = app.BankKeeper.DelegateCoins(ctx, addrs[0], app.AccountKeeper.GetModuleAddress(stakingtypes.BondedPoolName), invalidSendAmount)
+	err = app.BankKeeper.DelegateCoins(ctx, addrs[0], app.AccountKeeper.GetModuleAddress(stakingtypes.BondedPoolName), invalidBlockSendAmount)
 	require.Error(t, err)
+	err = app.BankKeeper.DelegateCoins(ctx, addrs[0], app.AccountKeeper.GetModuleAddress(stakingtypes.BondedPoolName), triggerTrackSendAmount)
+	require.Equal(t, countTrackBeforeSend, expNextCount)
+	expNextCount++
 
 	// make sure that UndelegateCoins doesn't bypass the hook
 	err = app.BankKeeper.UndelegateCoins(ctx, app.AccountKeeper.GetModuleAddress(stakingtypes.BondedPoolName), addrs[0], validSendAmount)
 	require.NoError(t, err)
-	err = app.BankKeeper.UndelegateCoins(ctx, app.AccountKeeper.GetModuleAddress(stakingtypes.BondedPoolName), addrs[0], invalidSendAmount)
+	err = app.BankKeeper.UndelegateCoins(ctx, app.AccountKeeper.GetModuleAddress(stakingtypes.BondedPoolName), addrs[0], invalidBlockSendAmount)
 	require.Error(t, err)
+
+	err = app.BankKeeper.UndelegateCoins(ctx, app.AccountKeeper.GetModuleAddress(stakingtypes.BondedPoolName), addrs[0], triggerTrackSendAmount)
+	require.Equal(t, countTrackBeforeSend, expNextCount)
+	expNextCount++
 }

--- a/x/bank/keeper/keeper.go
+++ b/x/bank/keeper/keeper.go
@@ -183,11 +183,12 @@ func (k BaseKeeper) DelegateCoins(ctx sdk.Context, delegatorAddr, moduleAccAddr 
 		return sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, amt.String())
 	}
 
-	// call the BeforeSend hooks
-	err := k.BeforeSend(ctx, delegatorAddr, moduleAccAddr, amt)
+	err := k.BlockBeforeSend(ctx, delegatorAddr, moduleAccAddr, amt)
 	if err != nil {
 		return err
 	}
+	// call the TrackBeforeSend hooks and the BlockBeforeSend hooks
+	k.TrackBeforeSend(ctx, delegatorAddr, moduleAccAddr, amt)
 
 	balances := sdk.NewCoins()
 
@@ -237,11 +238,13 @@ func (k BaseKeeper) UndelegateCoins(ctx sdk.Context, moduleAccAddr, delegatorAdd
 		return sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, amt.String())
 	}
 
-	// call the BeforeSend hooks
-	err := k.BeforeSend(ctx, moduleAccAddr, delegatorAddr, amt)
+	// call the TrackBeforeSend hooks and the BlockBeforeSend hooks
+	err := k.BlockBeforeSend(ctx, moduleAccAddr, delegatorAddr, amt)
 	if err != nil {
 		return err
 	}
+
+	k.TrackBeforeSend(ctx, moduleAccAddr, delegatorAddr, amt)
 
 	err = k.subUnlockedCoins(ctx, moduleAccAddr, amt)
 	if err != nil {
@@ -441,6 +444,8 @@ func (k BaseKeeper) SendCoinsFromModuleToManyAccounts(
 
 // SendCoinsFromModuleToModule transfers coins from a ModuleAccount to another.
 // It will panic if either module account does not exist.
+// SendCoinsFromModuleToModule is the only send method that does not call both BlockBeforeSend and TrackBeforeSend hook.
+// It only calls the TrackBeforeSend hook.
 func (k BaseKeeper) SendCoinsFromModuleToModule(
 	ctx sdk.Context, senderModule, recipientModule string, amt sdk.Coins,
 ) error {
@@ -455,7 +460,7 @@ func (k BaseKeeper) SendCoinsFromModuleToModule(
 		panic(sdkerrors.Wrapf(sdkerrors.ErrUnknownAddress, "module account %s does not exist", recipientModule))
 	}
 
-	return k.SendCoins(ctx, senderAddr, recipientAcc.GetAddress(), amt)
+	return k.SendCoinsWithoutBlockHook(ctx, senderAddr, recipientAcc.GetAddress(), amt)
 }
 
 // SendCoinsFromAccountToModule transfers coins from an AccAddress to a ModuleAccount.

--- a/x/bank/types/expected_keepers.go
+++ b/x/bank/types/expected_keepers.go
@@ -35,5 +35,6 @@ type AccountKeeper interface {
 
 // BankHooks event hooks for bank sends
 type BankHooks interface {
-	BeforeSend(ctx sdk.Context, from sdk.AccAddress, to sdk.AccAddress, amount sdk.Coins) error // Must be before any send is executed
+	TrackBeforeSend(ctx sdk.Context, from, to sdk.AccAddress, amount sdk.Coins)       // Must be before any send is executed
+	BlockBeforeSend(ctx sdk.Context, from, to sdk.AccAddress, amount sdk.Coins) error // Must be before any send is executed
 }

--- a/x/bank/types/hooks.go
+++ b/x/bank/types/hooks.go
@@ -12,10 +12,17 @@ func NewMultiBankHooks(hooks ...BankHooks) MultiBankHooks {
 	return hooks
 }
 
-// BeforeSend runs the BeforeSend hooks in order for each BankHook in a MultiBankHooks struct
-func (h MultiBankHooks) BeforeSend(ctx sdk.Context, from, to sdk.AccAddress, amount sdk.Coins) error {
+// TrackBeforeSend runs the TrackBeforeSend hooks in order for each BankHook in a MultiBankHooks struct
+func (h MultiBankHooks) TrackBeforeSend(ctx sdk.Context, from, to sdk.AccAddress, amount sdk.Coins) {
 	for i := range h {
-		err := h[i].BeforeSend(ctx, from, to, amount)
+		h[i].TrackBeforeSend(ctx, from, to, amount)
+	}
+}
+
+// BlockBeforeSend runs the BlockBeforeSend hooks in order for each BankHook in a MultiBankHooks struct
+func (h MultiBankHooks) BlockBeforeSend(ctx sdk.Context, from, to sdk.AccAddress, amount sdk.Coins) error {
+	for i := range h {
+		err := h[i].BlockBeforeSend(ctx, from, to, amount)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->
## What is the purpose of the change
This PR adds `TrackBeforeSend` hook and `BlockBeforeSend` hook, and deprecates `BeforeSend` hook.
Each hook, respectively would call the hook that has been registered from a different module.
The difference between the two new hooks being introduced is that `TrackBeforesend` hook does not have the ability to cause any effect, as it does not emit errors. Meanwhile, `BlockBeforeSend` does emit errors, allowing connected hooks to stop and block the send.

Additional method `SendCoinsWithoutBlockHook` has also been added along with the two hooks, as for module <> module transfers, we want to ensure it does not get blocked by external hooks.


## Brief Changelog
Add `TrackBeforeSend` , `BlockBeforeSend` hooks. Deprecate `BeforeSend` hook

## Testing and Verifying
This change adds tests

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)
