### PR TITLE
chore: Remove burn logs from Bank module

### DIFF
--- a/x/bank/keeper/keeper.go
+++ b/x/bank/keeper/keeper.go
@@ -577,6 +577,9 @@ func (k BaseKeeper) BurnCoins(ctx sdk.Context, moduleName string, amounts sdk.Co
 		k.setSupply(ctx, supply)
 	}
 
+	logger := k.Logger(ctx)
+	logger.Debug("burned tokens from module account", "amount", amounts.String(), "from", moduleName)
+
 	// emit burn event
 	ctx.EventManager().EmitEvent(
 		types.NewCoinBurnEvent(acc.GetAddress(), amounts),

--- a/x/bank/keeper/keeper.go
+++ b/x/bank/keeper/keeper.go
@@ -577,9 +577,6 @@ func (k BaseKeeper) BurnCoins(ctx sdk.Context, moduleName string, amounts sdk.Co
 		k.setSupply(ctx, supply)
 	}
 
-	logger := k.Logger(ctx)
-	logger.Info("burned tokens from module account", "amount", amounts.String(), "from", moduleName)
-
 	// emit burn event
 	ctx.EventManager().EmitEvent(
 		types.NewCoinBurnEvent(acc.GetAddress(), amounts),


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: https://github.com/osmosis-labs/osmosis/issues/4540

## What is the purpose of the change

Removes Burn Logs from Bank module. 

We have alot of incidences where we Burn coins, for example, whenever user exits a pool, it would burn the pool shares, triggering this log layer. 

We also have future incidences where we will have multiples of simultaneous burns, e,g when we are migrating shares from one pool to other. This would cause log bombs in nodes as shown in the original issue. 

This PR removes log bombs caused from burns. 

## Brief Changelog
- Remove burn logs from Bank module.


## Testing and Verifying


This change does not need tests
## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)
