### PR TITLE
fix: PowerMut incorrect precision

### DIFF
--- a/types/decimal.go
+++ b/types/decimal.go
@@ -499,8 +499,7 @@ func (d Dec) Power(power uint64) Dec {
 func (d Dec) PowerMut(power uint64) Dec {
 	// TODO: use mutable functions here
 	if power == 0 {
-		d.i.SetInt64(1)
-		return d
+		return OneDec()
 	} else if power == 1 {
 		return d
 	}

--- a/types/decimal.go
+++ b/types/decimal.go
@@ -499,7 +499,8 @@ func (d Dec) Power(power uint64) Dec {
 func (d Dec) PowerMut(power uint64) Dec {
 	// TODO: use mutable functions here
 	if power == 0 {
-		return OneDec()
+		// Set to 1 with the correct precision.
+		d.i.Set(precisionReuse)
 	} else if power == 1 {
 		return d
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Optimization in https://github.com/osmosis-labs/cosmos-sdk/pull/443 broke an edge case.

The earlier change would initialize one to incorrect precision. This fixes the bug. Tested on the osmosis that all test cases pass.