### PR TITLE
fix: events are not emitted after proposal gets handled

### DIFF
--- a/x/gov/abci.go
+++ b/x/gov/abci.go
@@ -79,6 +79,9 @@ func EndBlocker(ctx sdk.Context, keeper keeper.Keeper) {
 
 				// write state to the underlying multi-store
 				writeCache()
+				// emit events from cache context manually
+				// required due to https://github.com/osmosis-labs/cosmos-sdk/pull/384 which makes `writeCache` omit emitting events
+				ctx.EventManager().EmitEvents(cacheCtx.EventManager().Events())
 			} else {
 				proposal.Status = types.StatusFailed
 				tagValue = types.AttributeValueProposalFailed


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes #466 

## What is the purpose of the change

Due to https://github.com/osmosis-labs/cosmos-sdk/pull/384 which makes `writeCache` omit emitting events, gov `EndBlockers` does not emit events after proposal handled. This PR fix the issue by manually re-emitting events from cache context. 


