### PR TITLE
fix: mul round up for negative values doesn't round up

### DIFF
--- a/types/decimal.go
+++ b/types/decimal.go
@@ -655,7 +655,7 @@ func chopPrecisionAndRoundUp(d *big.Int) *big.Int {
 		// make d positive, compute chopped value, and then un-mutate d
 		d = d.Neg(d)
 		// truncate since d is negative...
-		chopPrecisionAndTruncate(d)
+		chopPrecisionAndRoundUp(d)
 		d = d.Neg(d)
 		return d
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Fix for `MulRoundUp` where it actually truncates at precision end for negative values.
