### PR TITLE
Minimal state streaming backport

### DIFF
--- a/baseapp/baseapp_test.go
+++ b/baseapp/baseapp_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	pruningtypes "github.com/cosmos/cosmos-sdk/pruning/types"
+	"github.com/cosmos/cosmos-sdk/simapp/params"
 	"github.com/cosmos/cosmos-sdk/snapshots"
 	snapshottypes "github.com/cosmos/cosmos-sdk/snapshots/types"
 	"github.com/cosmos/cosmos-sdk/store/rootmulti"
@@ -941,19 +942,19 @@ func testTxDecoder(cdc *codec.LegacyAmino) sdk.TxDecoder {
 func anteHandlerTxTest(t *testing.T, capKey sdk.StoreKey, storeKey []byte) sdk.AnteHandler {
 	return func(ctx sdk.Context, tx sdk.Tx, simulate bool) (sdk.Context, error) {
 		store := ctx.KVStore(capKey)
-		txTest := tx.(txTest)
+		counter, failOnAnte := parseTxMemo(t, tx)
 
-		if txTest.FailOnAnte {
+		if failOnAnte {
 			return ctx, sdkerrors.Wrap(sdkerrors.ErrUnauthorized, "ante handler failure")
 		}
 
-		_, err := incrementingCounter(t, store, storeKey, txTest.Counter)
+		_, err := incrementingCounter(t, store, storeKey, counter)
 		if err != nil {
 			return ctx, err
 		}
 
 		ctx.EventManager().EmitEvents(
-			counterEvent("ante_handler", txTest.Counter),
+			counterEvent("ante_handler", counter),
 		)
 
 		return ctx, nil
@@ -1059,8 +1060,10 @@ func TestCheckTx(t *testing.T) {
 	codec := codec.NewLegacyAmino()
 	registerTestCodec(codec)
 
+	encCfg := params.MakeTestEncodingConfig()
+
 	for i := int64(0); i < nTxs; i++ {
-		tx := newTxCounter(i, 0) // no messages
+		tx := newWrappedTxCounter(encCfg.TxConfig, i, 0)
 		txBytes, err := codec.Marshal(tx)
 		require.NoError(t, err)
 		r := app.CheckTx(abci.RequestCheckTx{Tx: txBytes})

--- a/baseapp/options.go
+++ b/baseapp/options.go
@@ -7,6 +7,8 @@ import (
 
 	dbm "github.com/tendermint/tm-db"
 
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+
 	"github.com/cosmos/cosmos-sdk/codec/types"
 	pruningtypes "github.com/cosmos/cosmos-sdk/pruning/types"
 	"github.com/cosmos/cosmos-sdk/snapshots"
@@ -246,4 +248,9 @@ func (app *BaseApp) SetInterfaceRegistry(registry types.InterfaceRegistry) {
 	app.interfaceRegistry = registry
 	app.grpcQueryRouter.SetInterfaceRegistry(registry)
 	app.msgServiceRouter.SetInterfaceRegistry(registry)
+}
+
+// SetStreamingManager sets the streaming manager for the BaseApp.
+func (app *BaseApp) SetStreamingManager(manager storetypes.StreamingManager) {
+	app.streamingManager = manager
 }

--- a/baseapp/streaming_test.go
+++ b/baseapp/streaming_test.go
@@ -1,0 +1,208 @@
+package baseapp
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strconv"
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/require"
+	abci "github.com/tendermint/tendermint/abci/types"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+	dbm "github.com/tendermint/tm-db"
+
+	baseapptestutil "github.com/cosmos/cosmos-sdk/baseapp/testutil"
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth/signing"
+	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
+)
+
+var _ storetypes.ABCIListener = (*MockABCIListener)(nil)
+
+type MockABCIListener struct {
+	name      string
+	ChangeSet []*storetypes.StoreKVPair
+}
+
+func NewMockABCIListener(name string) MockABCIListener {
+	return MockABCIListener{
+		name:      name,
+		ChangeSet: make([]*storetypes.StoreKVPair, 0),
+	}
+}
+
+func (m *MockABCIListener) ListenBeginBlock(context.Context, abci.RequestBeginBlock, abci.ResponseBeginBlock) error {
+	return nil
+}
+
+func (m *MockABCIListener) ListenEndBlock(context.Context, abci.RequestEndBlock, abci.ResponseEndBlock) error {
+	return nil
+}
+
+func (m *MockABCIListener) ListenDeliverTx(context.Context, abci.RequestDeliverTx, abci.ResponseDeliverTx) error {
+	return nil
+}
+
+func (m *MockABCIListener) ListenCommit(_ context.Context, _ abci.ResponseCommit, changeSet []*storetypes.StoreKVPair) error {
+	m.ChangeSet = changeSet
+	return nil
+}
+
+var distKey1 = storetypes.NewKVStoreKey("distKey1")
+
+type BaseAppSuite struct {
+	baseApp  *BaseApp
+	cdc      *codec.ProtoCodec
+	txConfig client.TxConfig
+}
+
+func newBaseAppSuite(t *testing.T, opts ...func(*BaseApp)) *BaseAppSuite {
+	cdc := codec.NewProtoCodec(codectypes.NewInterfaceRegistry())
+	baseapptestutil.RegisterInterfaces(cdc.InterfaceRegistry())
+
+	txConfig := authtx.NewTxConfig(cdc, authtx.DefaultSignModes)
+	db := dbm.NewMemDB()
+
+	app := NewBaseApp(t.Name(), defaultLogger(), db, txConfig.TxDecoder(), opts...)
+	require.Equal(t, t.Name(), app.Name())
+
+	app.SetInterfaceRegistry(cdc.InterfaceRegistry())
+	app.MsgServiceRouter().SetInterfaceRegistry(cdc.InterfaceRegistry())
+	app.MountStores(capKey1, capKey2)
+	app.SetParamStore(&paramStore{db: dbm.NewMemDB()})
+
+	// mount stores and seal
+	require.Nil(t, app.LoadLatestVersion())
+
+	return &BaseAppSuite{
+		baseApp:  app,
+		cdc:      cdc,
+		txConfig: txConfig,
+	}
+}
+
+func newWrappedTxCounter(cfg client.TxConfig, counter int64, msgCounters ...int64) signing.Tx {
+	msgs := make([]sdk.Msg, 0, len(msgCounters))
+	for _, c := range msgCounters {
+		msg := &baseapptestutil.MsgCounter{Counter: c, FailOnHandler: false}
+		msgs = append(msgs, msg)
+	}
+
+	builder := cfg.NewTxBuilder()
+	builder.SetMsgs(msgs...)
+	builder.SetMemo("counter=" + strconv.FormatInt(counter, 10) + "&failOnAnte=false")
+
+	return builder.GetTx()
+}
+
+func TestABCI_MultiListener_StateChanges(t *testing.T) {
+	anteKey := []byte("ante-key")
+	anteOpt := func(bapp *BaseApp) { bapp.SetAnteHandler(anteHandlerTxTest(t, capKey1, anteKey)) }
+	distOpt := func(bapp *BaseApp) { bapp.MountStores(distKey1) }
+	mockListener1 := NewMockABCIListener("lis_1")
+	mockListener2 := NewMockABCIListener("lis_2")
+	streamingManager := storetypes.StreamingManager{ABCIListeners: []storetypes.ABCIListener{&mockListener1, &mockListener2}}
+	streamingManagerOpt := func(bapp *BaseApp) { bapp.SetStreamingManager(streamingManager) }
+	addListenerOpt := func(bapp *BaseApp) { bapp.CommitMultiStore().AddListeners([]storetypes.StoreKey{distKey1}) }
+	suite := newBaseAppSuite(t, anteOpt, distOpt, streamingManagerOpt, addListenerOpt)
+
+	suite.baseApp.InitChain(abci.RequestInitChain{
+		ConsensusParams: &abci.ConsensusParams{},
+	})
+
+	deliverKey := []byte("deliver-key")
+	baseapptestutil.RegisterCounterServer(suite.baseApp.MsgServiceRouter(), CounterServerImpl{t, capKey1, deliverKey})
+
+	nBlocks := 3
+	txPerHeight := 5
+
+	for blockN := 0; blockN < nBlocks; blockN++ {
+		header := tmproto.Header{Height: int64(blockN) + 1}
+		suite.baseApp.BeginBlock(abci.RequestBeginBlock{Header: header})
+		var expectedChangeSet []*storetypes.StoreKVPair
+
+		for i := 0; i < txPerHeight; i++ {
+			counter := int64(blockN*txPerHeight + i)
+			tx := newWrappedTxCounter(suite.txConfig, counter, counter)
+
+			txBytes, err := suite.txConfig.TxEncoder()(tx)
+			require.NoError(t, err)
+
+			sKey := []byte(fmt.Sprintf("distKey%d", i))
+			sVal := []byte(fmt.Sprintf("distVal%d", i))
+			deliverCtx := getDeliverStateCtx(suite.baseApp)
+			store := deliverCtx.KVStore(distKey1)
+			store.Set(sKey, sVal)
+
+			expectedChangeSet = append(expectedChangeSet, &storetypes.StoreKVPair{
+				StoreKey: distKey1.Name(),
+				Delete:   false,
+				Key:      sKey,
+				Value:    sVal,
+			})
+
+			res := suite.baseApp.DeliverTx(abci.RequestDeliverTx{Tx: txBytes})
+			require.True(t, res.IsOK(), fmt.Sprintf("%v", res))
+
+			events := res.GetEvents()
+			require.Len(t, events, 3, "should contain ante handler, message type and counter events respectively")
+			require.Equal(t, sdk.MarkEventsToIndex(counterEvent("ante_handler", counter).ToABCIEvents(), map[string]struct{}{})[0], events[0], "ante handler event")
+			require.Equal(t, sdk.MarkEventsToIndex(counterEvent(sdk.EventTypeMessage, counter).ToABCIEvents(), map[string]struct{}{})[0], events[2], "msg handler update counter event")
+		}
+
+		suite.baseApp.EndBlock(abci.RequestEndBlock{})
+		suite.baseApp.Commit()
+
+		require.Equal(t, expectedChangeSet, mockListener1.ChangeSet, "should contain the same changeSet")
+		require.Equal(t, expectedChangeSet, mockListener2.ChangeSet, "should contain the same changeSet")
+	}
+}
+
+func Test_Ctx_with_StreamingManager(t *testing.T) {
+	mockListener1 := NewMockABCIListener("lis_1")
+	mockListener2 := NewMockABCIListener("lis_2")
+	listeners := []storetypes.ABCIListener{&mockListener1, &mockListener2}
+	streamingManager := storetypes.StreamingManager{ABCIListeners: listeners, StopNodeOnErr: true}
+	streamingManagerOpt := func(bapp *BaseApp) { bapp.SetStreamingManager(streamingManager) }
+	addListenerOpt := func(bapp *BaseApp) { bapp.CommitMultiStore().AddListeners([]storetypes.StoreKey{distKey1}) }
+	suite := newBaseAppSuite(t, streamingManagerOpt, addListenerOpt)
+
+	suite.baseApp.InitChain(abci.RequestInitChain{
+		ConsensusParams: &abci.ConsensusParams{},
+	})
+
+	ctx := getDeliverStateCtx(suite.baseApp)
+	sm := ctx.StreamingManager()
+	require.NotNil(t, sm, fmt.Sprintf("nil StreamingManager: %v", sm))
+	require.Equal(t, listeners, sm.ABCIListeners, fmt.Sprintf("should contain same listeners: %v", listeners))
+	require.Equal(t, true, sm.StopNodeOnErr, "should contain StopNodeOnErr = true")
+
+	nBlocks := 2
+
+	for blockN := 0; blockN < nBlocks; blockN++ {
+		header := tmproto.Header{Height: int64(blockN) + 1}
+		suite.baseApp.BeginBlock(abci.RequestBeginBlock{Header: header})
+
+		ctx := getDeliverStateCtx(suite.baseApp)
+		sm := ctx.StreamingManager()
+		require.NotNil(t, sm, fmt.Sprintf("nil StreamingManager: %v", sm))
+		require.Equal(t, listeners, sm.ABCIListeners, fmt.Sprintf("should contain same listeners: %v", listeners))
+		require.Equal(t, true, sm.StopNodeOnErr, "should contain StopNodeOnErr = true")
+
+		suite.baseApp.EndBlock(abci.RequestEndBlock{})
+		suite.baseApp.Commit()
+	}
+}
+
+func getDeliverStateCtx(app *BaseApp) sdk.Context {
+	v := reflect.ValueOf(app).Elem()
+	f := v.FieldByName("deliverState")
+	rf := reflect.NewAt(f.Type(), unsafe.Pointer(f.UnsafeAddr())).Elem()
+	return rf.MethodByName("Context").Call(nil)[0].Interface().(sdk.Context)
+}

--- a/baseapp/utils_test.go
+++ b/baseapp/utils_test.go
@@ -1,0 +1,80 @@
+package baseapp
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	baseapptestutil "github.com/cosmos/cosmos-sdk/baseapp/testutil"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+type CounterServerImpl struct {
+	t          *testing.T
+	capKey     storetypes.StoreKey
+	deliverKey []byte
+}
+
+func (m CounterServerImpl) IncrementCounter(ctx context.Context, msg *baseapptestutil.MsgCounter) (*baseapptestutil.MsgCreateCounterResponse, error) {
+	return incrementCounter(ctx, m.t, m.capKey, m.deliverKey, msg)
+}
+
+func incrementCounter(ctx context.Context,
+	t *testing.T,
+	capKey storetypes.StoreKey,
+	deliverKey []byte,
+	msg sdk.Msg,
+) (*baseapptestutil.MsgCreateCounterResponse, error) {
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+	store := sdkCtx.KVStore(capKey)
+
+	sdkCtx.GasMeter().ConsumeGas(5, "test")
+
+	var msgCount int64
+
+	switch m := msg.(type) {
+	case *baseapptestutil.MsgCounter:
+		if m.FailOnHandler {
+			return nil, errors.New("message handler failure")
+			//return nil, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "message handler failure")
+		}
+		msgCount = m.Counter
+	case *baseapptestutil.MsgCounter2:
+		if m.FailOnHandler {
+			return nil, errors.New("message handler failure")
+			//return nil, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "message handler failure")
+		}
+		msgCount = m.Counter
+	}
+
+	sdkCtx.EventManager().EmitEvents(
+		counterEvent(sdk.EventTypeMessage, msgCount),
+	)
+
+	_, err := incrementingCounter(t, store, deliverKey, msgCount)
+	if err != nil {
+		return nil, err
+	}
+
+	return &baseapptestutil.MsgCreateCounterResponse{}, nil
+}
+
+func parseTxMemo(t *testing.T, tx sdk.Tx) (counter int64, failOnAnte bool) {
+	txWithMemo, ok := tx.(sdk.TxWithMemo)
+	require.True(t, ok)
+
+	memo := txWithMemo.GetMemo()
+	vals, err := url.ParseQuery(memo)
+	require.NoError(t, err)
+
+	counter, err = strconv.ParseInt(vals.Get("counter"), 10, 64)
+	require.NoError(t, err)
+
+	failOnAnte = vals.Get("failOnAnte") == "true"
+	return counter, failOnAnte
+}

--- a/proto/cosmos/base/store/v1beta1/listening.proto
+++ b/proto/cosmos/base/store/v1beta1/listening.proto
@@ -14,3 +14,10 @@ message StoreKVPair {
   bytes key        = 3;
   bytes value      = 4;
 }
+
+message StoreKVPairs {
+  repeated StoreKVPair pairs = 1;
+  int64 block_height = 2;
+  string store_key = 3;
+  bytes key_prefix = 4;
+}

--- a/snapshots/store.go
+++ b/snapshots/store.go
@@ -307,7 +307,7 @@ func (*Store) CacheWrapWithTrace(_ io.Writer, _ store.TraceContext) store.CacheW
 }
 
 // CacheWrapWithListeners implements the Store interface.
-func (*Store) CacheWrapWithListeners(_ store.StoreKey, _ []store.WriteListener) store.CacheWrap {
+func (*Store) CacheWrapWithListeners(storeKey store.StoreKey, listeners any) store.CacheWrap {
 	panic("cannot CacheWrapWithListeners a snapshot Store")
 }
 

--- a/store/cachekv/store.go
+++ b/store/cachekv/store.go
@@ -2,11 +2,11 @@ package cachekv
 
 import (
 	"bytes"
-	"github.com/cosmos/cosmos-sdk/store/cachekv/internal"
-	"github.com/cosmos/cosmos-sdk/store/listenkv"
 	"io"
 	"sort"
 	"sync"
+
+	"github.com/cosmos/cosmos-sdk/store/cachekv/internal"
 
 	dbm "github.com/tendermint/tm-db"
 
@@ -401,8 +401,4 @@ func (store *Store) setCacheValue(key, value []byte, dirty bool) {
 	if dirty {
 		store.unsortedCache[keyStr] = struct{}{}
 	}
-}
-
-func (store *Store) CacheWrapWithListeners(storeKey types.StoreKey, listeners []types.WriteListener) types.CacheWrap {
-	return NewStore(listenkv.NewStore(store, storeKey, listeners))
 }

--- a/store/dbadapter/store.go
+++ b/store/dbadapter/store.go
@@ -6,7 +6,6 @@ import (
 	dbm "github.com/tendermint/tm-db"
 
 	"github.com/cosmos/cosmos-sdk/store/cachekv"
-	"github.com/cosmos/cosmos-sdk/store/listenkv"
 	"github.com/cosmos/cosmos-sdk/store/tracekv"
 	"github.com/cosmos/cosmos-sdk/store/types"
 )
@@ -84,11 +83,6 @@ func (dsa Store) CacheWrap() types.CacheWrap {
 // CacheWrapWithTrace implements KVStore.
 func (dsa Store) CacheWrapWithTrace(w io.Writer, tc types.TraceContext) types.CacheWrap {
 	return cachekv.NewStore(tracekv.NewStore(dsa, w, tc))
-}
-
-// CacheWrapWithListeners implements the CacheWrapper interface.
-func (dsa Store) CacheWrapWithListeners(storeKey types.StoreKey, listeners []types.WriteListener) types.CacheWrap {
-	return cachekv.NewStore(listenkv.NewStore(dsa, storeKey, listeners))
 }
 
 // dbm.DB implements KVStore so we can CacheKVStore it.

--- a/store/dbadapter/store_test.go
+++ b/store/dbadapter/store_test.go
@@ -84,7 +84,4 @@ func TestCacheWraps(t *testing.T) {
 
 	cacheWrappedWithTrace := store.CacheWrapWithTrace(nil, nil)
 	require.IsType(t, &cachekv.Store{}, cacheWrappedWithTrace)
-
-	cacheWrappedWithListeners := store.CacheWrapWithListeners(nil, nil)
-	require.IsType(t, &cachekv.Store{}, cacheWrappedWithListeners)
 }

--- a/store/gaskv/store.go
+++ b/store/gaskv/store.go
@@ -97,7 +97,7 @@ func (gs *Store) CacheWrapWithTrace(_ io.Writer, _ types.TraceContext) types.Cac
 }
 
 // CacheWrapWithListeners implements the CacheWrapper interface.
-func (gs *Store) CacheWrapWithListeners(_ types.StoreKey, _ []types.WriteListener) types.CacheWrap {
+func (gs *Store) CacheWrapWithListeners(storeKey types.StoreKey, listeners any) types.CacheWrap {
 	panic("cannot CacheWrapWithListeners a GasKVStore")
 }
 

--- a/store/iavl/store.go
+++ b/store/iavl/store.go
@@ -16,7 +16,6 @@ import (
 
 	pruningtypes "github.com/cosmos/cosmos-sdk/pruning/types"
 	"github.com/cosmos/cosmos-sdk/store/cachekv"
-	"github.com/cosmos/cosmos-sdk/store/listenkv"
 	"github.com/cosmos/cosmos-sdk/store/tracekv"
 	"github.com/cosmos/cosmos-sdk/store/types"
 	"github.com/cosmos/cosmos-sdk/telemetry"
@@ -188,11 +187,6 @@ func (st *Store) CacheWrap() types.CacheWrap {
 // CacheWrapWithTrace implements the Store interface.
 func (st *Store) CacheWrapWithTrace(w io.Writer, tc types.TraceContext) types.CacheWrap {
 	return cachekv.NewStore(tracekv.NewStore(st, w, tc))
-}
-
-// CacheWrapWithListeners implements the CacheWrapper interface.
-func (st *Store) CacheWrapWithListeners(storeKey types.StoreKey, listeners []types.WriteListener) types.CacheWrap {
-	return cachekv.NewStore(listenkv.NewStore(st, storeKey, listeners))
 }
 
 // Implements types.KVStore.

--- a/store/iavl/store_test.go
+++ b/store/iavl/store_test.go
@@ -660,7 +660,4 @@ func TestCacheWraps(t *testing.T) {
 
 	cacheWrappedWithTrace := store.CacheWrapWithTrace(nil, nil)
 	require.IsType(t, &cachekv.Store{}, cacheWrappedWithTrace)
-
-	cacheWrappedWithListeners := store.CacheWrapWithListeners(nil, nil)
-	require.IsType(t, &cachekv.Store{}, cacheWrappedWithListeners)
 }

--- a/store/listenkv/store.go
+++ b/store/listenkv/store.go
@@ -13,14 +13,14 @@ var _ types.KVStore = &Store{}
 // underlying listeners with the proper key and operation permissions
 type Store struct {
 	parent         types.KVStore
-	listeners      []types.WriteListener
 	parentStoreKey types.StoreKey
+	listener       *types.MemoryListener
 }
 
 // NewStore returns a reference to a new traceKVStore given a parent
 // KVStore implementation and a buffered writer.
-func NewStore(parent types.KVStore, parentStoreKey types.StoreKey, listeners []types.WriteListener) *Store {
-	return &Store{parent: parent, listeners: listeners, parentStoreKey: parentStoreKey}
+func NewStore(parent types.KVStore, parentStoreKey types.StoreKey, listener *types.MemoryListener) *Store {
+	return &Store{parent: parent, listener: listener, parentStoreKey: parentStoreKey}
 }
 
 // Get implements the KVStore interface. It traces a read operation and
@@ -35,14 +35,14 @@ func (s *Store) Get(key []byte) []byte {
 func (s *Store) Set(key []byte, value []byte) {
 	types.AssertValidKey(key)
 	s.parent.Set(key, value)
-	s.onWrite(false, key, value)
+	s.listener.OnWrite(s.parentStoreKey, key, value, false)
 }
 
 // Delete implements the KVStore interface. It traces a write operation and
 // delegates the Delete call to the parent KVStore.
 func (s *Store) Delete(key []byte) {
 	s.parent.Delete(key)
-	s.onWrite(true, key, nil)
+	s.listener.OnWrite(s.parentStoreKey, key, nil, true)
 }
 
 // Has implements the KVStore interface. It delegates the Has call to the
@@ -74,16 +74,15 @@ func (s *Store) iterator(start, end []byte, ascending bool) types.Iterator {
 		parent = s.parent.ReverseIterator(start, end)
 	}
 
-	return newTraceIterator(parent, s.listeners)
+	return newTraceIterator(parent)
 }
 
 type listenIterator struct {
-	parent    types.Iterator
-	listeners []types.WriteListener
+	parent types.Iterator
 }
 
-func newTraceIterator(parent types.Iterator, listeners []types.WriteListener) types.Iterator {
-	return &listenIterator{parent: parent, listeners: listeners}
+func newTraceIterator(parent types.Iterator) types.Iterator {
+	return &listenIterator{parent: parent}
 }
 
 // Domain implements the Iterator interface.
@@ -143,13 +142,6 @@ func (s *Store) CacheWrapWithTrace(_ io.Writer, _ types.TraceContext) types.Cach
 
 // CacheWrapWithListeners implements the KVStore interface. It panics as a
 // Store cannot be cache wrapped.
-func (s *Store) CacheWrapWithListeners(_ types.StoreKey, _ []types.WriteListener) types.CacheWrap {
+func (s *Store) CacheWrapWithListeners(storeKey types.StoreKey, listeners any) types.CacheWrap {
 	panic("cannot CacheWrapWithListeners a ListenKVStore")
-}
-
-// onWrite writes a KVStore operation to all of the WriteListeners
-func (s *Store) onWrite(delete bool, key, value []byte) {
-	for _, l := range s.listeners {
-		l.OnWrite(s.parentStoreKey, key, value, delete)
-	}
 }

--- a/store/listenkv/store_test.go
+++ b/store/listenkv/store_test.go
@@ -1,13 +1,9 @@
 package listenkv_test
 
 import (
-	"bytes"
 	"fmt"
-	"io"
 	"testing"
 
-	"github.com/cosmos/cosmos-sdk/codec"
-	codecTypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/store/dbadapter"
 	"github.com/cosmos/cosmos-sdk/store/listenkv"
 	"github.com/cosmos/cosmos-sdk/store/prefix"
@@ -30,11 +26,9 @@ var kvPairs = []types.KVPair{
 }
 
 var testStoreKey = types.NewKVStoreKey("listen_test")
-var interfaceRegistry = codecTypes.NewInterfaceRegistry()
-var testMarshaller = codec.NewProtoCodec(interfaceRegistry)
 
-func newListenKVStore(w io.Writer) *listenkv.Store {
-	store := newEmptyListenKVStore(w)
+func newListenKVStore(listener *types.MemoryListener) *listenkv.Store {
+	store := newEmptyListenKVStore(listener)
 
 	for _, kvPair := range kvPairs {
 		store.Set(kvPair.Key, kvPair.Value)
@@ -43,11 +37,10 @@ func newListenKVStore(w io.Writer) *listenkv.Store {
 	return store
 }
 
-func newEmptyListenKVStore(w io.Writer) *listenkv.Store {
-	listener := types.NewStoreKVPairWriteListener(w, testMarshaller)
+func newEmptyListenKVStore(listener *types.MemoryListener) *listenkv.Store {
 	memDB := dbadapter.Store{DB: dbm.NewMemDB()}
 
-	return listenkv.NewStore(memDB, testStoreKey, []types.WriteListener{listener})
+	return listenkv.NewStore(memDB, testStoreKey, listener)
 }
 
 func TestListenKVStoreGet(t *testing.T) {
@@ -66,10 +59,9 @@ func TestListenKVStoreGet(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		var buf bytes.Buffer
+		listener := types.NewMemoryListener()
 
-		store := newListenKVStore(&buf)
-		buf.Reset()
+		store := newListenKVStore(listener)
 		value := store.Get(tc.key)
 
 		require.Equal(t, tc.expectedValue, value)
@@ -115,19 +107,17 @@ func TestListenKVStoreSet(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		var buf bytes.Buffer
+		listener := types.NewMemoryListener()
 
-		store := newEmptyListenKVStore(&buf)
-		buf.Reset()
+		store := newEmptyListenKVStore(listener)
 		store.Set(tc.key, tc.value)
-		storeKVPair := new(types.StoreKVPair)
-		testMarshaller.UnmarshalLengthPrefixed(buf.Bytes(), storeKVPair)
+		storeKVPair := listener.PopStateCache()[0]
 
 		require.Equal(t, tc.expectedOut, storeKVPair)
 	}
 
-	var buf bytes.Buffer
-	store := newEmptyListenKVStore(&buf)
+	listener := types.NewMemoryListener()
+	store := newEmptyListenKVStore(listener)
 	require.Panics(t, func() { store.Set([]byte(""), []byte("value")) }, "setting an empty key should panic")
 	require.Panics(t, func() { store.Set(nil, []byte("value")) }, "setting a nil key should panic")
 
@@ -150,13 +140,13 @@ func TestListenKVStoreDelete(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		var buf bytes.Buffer
+		listener := types.NewMemoryListener()
 
-		store := newListenKVStore(&buf)
-		buf.Reset()
+		store := newListenKVStore(listener)
 		store.Delete(tc.key)
-		storeKVPair := new(types.StoreKVPair)
-		testMarshaller.UnmarshalLengthPrefixed(buf.Bytes(), storeKVPair)
+		cache := listener.PopStateCache()
+		require.NotEmpty(t, cache)
+		storeKVPair := cache[len(cache)-1]
 
 		require.Equal(t, tc.expectedOut, storeKVPair)
 	}
@@ -174,10 +164,9 @@ func TestListenKVStoreHas(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		var buf bytes.Buffer
+		listener := types.NewMemoryListener()
 
-		store := newListenKVStore(&buf)
-		buf.Reset()
+		store := newListenKVStore(listener)
 		ok := store.Has(tc.key)
 
 		require.Equal(t, tc.expected, ok)
@@ -185,9 +174,9 @@ func TestListenKVStoreHas(t *testing.T) {
 }
 
 func TestTestListenKVStoreIterator(t *testing.T) {
-	var buf bytes.Buffer
+	listener := types.NewMemoryListener()
 
-	store := newListenKVStore(&buf)
+	store := newListenKVStore(listener)
 	iterator := store.Iterator(nil, nil)
 
 	s, e := iterator.Domain()
@@ -228,9 +217,8 @@ func TestTestListenKVStoreIterator(t *testing.T) {
 }
 
 func TestTestListenKVStoreReverseIterator(t *testing.T) {
-	var buf bytes.Buffer
-
-	store := newListenKVStore(&buf)
+	listener := types.NewMemoryListener()
+	store := newListenKVStore(listener)
 	iterator := store.ReverseIterator(nil, nil)
 
 	s, e := iterator.Domain()

--- a/store/mem/mem_test.go
+++ b/store/mem/mem_test.go
@@ -33,9 +33,6 @@ func TestStore(t *testing.T) {
 
 	cacheWrappedWithTrace := db.CacheWrapWithTrace(nil, nil)
 	require.IsType(t, &cachekv.Store{}, cacheWrappedWithTrace)
-
-	cacheWrappedWithListeners := db.CacheWrapWithListeners(nil, nil)
-	require.IsType(t, &cachekv.Store{}, cacheWrappedWithListeners)
 }
 
 func TestCommit(t *testing.T) {

--- a/store/mem/store.go
+++ b/store/mem/store.go
@@ -8,7 +8,6 @@ import (
 	pruningtypes "github.com/cosmos/cosmos-sdk/pruning/types"
 	"github.com/cosmos/cosmos-sdk/store/cachekv"
 	"github.com/cosmos/cosmos-sdk/store/dbadapter"
-	"github.com/cosmos/cosmos-sdk/store/listenkv"
 	"github.com/cosmos/cosmos-sdk/store/tracekv"
 	"github.com/cosmos/cosmos-sdk/store/types"
 )
@@ -45,11 +44,6 @@ func (s Store) CacheWrap() types.CacheWrap {
 // CacheWrapWithTrace implements KVStore.
 func (s Store) CacheWrapWithTrace(w io.Writer, tc types.TraceContext) types.CacheWrap {
 	return cachekv.NewStore(tracekv.NewStore(s, w, tc))
-}
-
-// CacheWrapWithListeners implements the CacheWrapper interface.
-func (s Store) CacheWrapWithListeners(storeKey types.StoreKey, listeners []types.WriteListener) types.CacheWrap {
-	return cachekv.NewStore(listenkv.NewStore(s, storeKey, listeners))
 }
 
 // Commit performs a no-op as entries are persistent between commitments.

--- a/store/prefix/store.go
+++ b/store/prefix/store.go
@@ -6,7 +6,6 @@ import (
 	"io"
 
 	"github.com/cosmos/cosmos-sdk/store/cachekv"
-	"github.com/cosmos/cosmos-sdk/store/listenkv"
 	"github.com/cosmos/cosmos-sdk/store/tracekv"
 	"github.com/cosmos/cosmos-sdk/store/types"
 )
@@ -56,11 +55,6 @@ func (s Store) CacheWrap() types.CacheWrap {
 // CacheWrapWithTrace implements the KVStore interface.
 func (s Store) CacheWrapWithTrace(w io.Writer, tc types.TraceContext) types.CacheWrap {
 	return cachekv.NewStore(tracekv.NewStore(s, w, tc))
-}
-
-// CacheWrapWithListeners implements the CacheWrapper interface.
-func (s Store) CacheWrapWithListeners(storeKey types.StoreKey, listeners []types.WriteListener) types.CacheWrap {
-	return cachekv.NewStore(listenkv.NewStore(s, storeKey, listeners))
 }
 
 // Implements KVStore

--- a/store/prefix/store_test.go
+++ b/store/prefix/store_test.go
@@ -438,7 +438,4 @@ func TestCacheWraps(t *testing.T) {
 
 	cacheWrappedWithTrace := store.CacheWrapWithTrace(nil, nil)
 	require.IsType(t, &cachekv.Store{}, cacheWrappedWithTrace)
-
-	cacheWrappedWithListeners := store.CacheWrapWithListeners(nil, nil)
-	require.IsType(t, &cachekv.Store{}, cacheWrappedWithListeners)
 }

--- a/store/tracekv/store.go
+++ b/store/tracekv/store.go
@@ -174,7 +174,7 @@ func (tkv *Store) CacheWrapWithTrace(_ io.Writer, _ types.TraceContext) types.Ca
 }
 
 // CacheWrapWithListeners implements the CacheWrapper interface.
-func (tkv *Store) CacheWrapWithListeners(_ types.StoreKey, _ []types.WriteListener) types.CacheWrap {
+func (tkv *Store) CacheWrapWithListeners(storeKey types.StoreKey, listeners any) types.CacheWrap {
 	panic("cannot CacheWrapWithListeners a TraceKVStore")
 }
 

--- a/store/types/listening.go
+++ b/store/types/listening.go
@@ -1,47 +1,28 @@
 package types
 
-import (
-	"io"
-
-	"github.com/cosmos/cosmos-sdk/codec"
-)
-
-// WriteListener interface for streaming data out from a listenkv.Store
-type WriteListener interface {
-	// if value is nil then it was deleted
-	// storeKey indicates the source KVStore, to facilitate using the the same WriteListener across separate KVStores
-	// delete bool indicates if it was a delete; true: delete, false: set
-	OnWrite(storeKey StoreKey, key []byte, value []byte, delete bool) error
+// MemoryListener listens to the state writes and accumulate the records in memory.
+type MemoryListener struct {
+	stateCache []*StoreKVPair
 }
 
-// StoreKVPairWriteListener is used to configure listening to a KVStore by writing out length-prefixed
-// protobuf encoded StoreKVPairs to an underlying io.Writer
-type StoreKVPairWriteListener struct {
-	writer     io.Writer
-	marshaller codec.BinaryCodec
+// NewMemoryListener creates a listener that accumulate the state writes in memory.
+func NewMemoryListener() *MemoryListener {
+	return &MemoryListener{}
 }
 
-// NewStoreKVPairWriteListener wraps creates a StoreKVPairWriteListener with a provdied io.Writer and codec.BinaryCodec
-func NewStoreKVPairWriteListener(w io.Writer, m codec.BinaryCodec) *StoreKVPairWriteListener {
-	return &StoreKVPairWriteListener{
-		writer:     w,
-		marshaller: m,
-	}
+// OnWrite implements MemoryListener interface
+func (fl *MemoryListener) OnWrite(storeKey StoreKey, key []byte, value []byte, delete bool) {
+	fl.stateCache = append(fl.stateCache, &StoreKVPair{
+		StoreKey: storeKey.Name(),
+		Delete:   delete,
+		Key:      key,
+		Value:    value,
+	})
 }
 
-// OnWrite satisfies the WriteListener interface by writing length-prefixed protobuf encoded StoreKVPairs
-func (wl *StoreKVPairWriteListener) OnWrite(storeKey StoreKey, key []byte, value []byte, delete bool) error {
-	kvPair := new(StoreKVPair)
-	kvPair.StoreKey = storeKey.Name()
-	kvPair.Delete = delete
-	kvPair.Key = key
-	kvPair.Value = value
-	by, err := wl.marshaller.MarshalLengthPrefixed(kvPair)
-	if err != nil {
-		return err
-	}
-	if _, err := wl.writer.Write(by); err != nil {
-		return err
-	}
-	return nil
+// PopStateCache returns the current state caches and set to nil
+func (fl *MemoryListener) PopStateCache() []*StoreKVPair {
+	res := fl.stateCache
+	fl.stateCache = nil
+	return res
 }

--- a/store/types/listening.pb.go
+++ b/store/types/listening.pb.go
@@ -95,8 +95,77 @@ func (m *StoreKVPair) GetValue() []byte {
 	return nil
 }
 
+type StoreKVPairs struct {
+	Pairs       []*StoreKVPair `protobuf:"bytes,1,rep,name=pairs,proto3" json:"pairs,omitempty"`
+	BlockHeight int64          `protobuf:"varint,2,opt,name=block_height,json=blockHeight,proto3" json:"block_height,omitempty"`
+	StoreKey    string         `protobuf:"bytes,3,opt,name=store_key,json=storeKey,proto3" json:"store_key,omitempty"`
+	KeyPrefix   []byte         `protobuf:"bytes,4,opt,name=key_prefix,json=keyPrefix,proto3" json:"key_prefix,omitempty"`
+}
+
+func (m *StoreKVPairs) Reset()         { *m = StoreKVPairs{} }
+func (m *StoreKVPairs) String() string { return proto.CompactTextString(m) }
+func (*StoreKVPairs) ProtoMessage()    {}
+func (*StoreKVPairs) Descriptor() ([]byte, []int) {
+	return fileDescriptor_a5d350879fe4fecd, []int{1}
+}
+func (m *StoreKVPairs) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *StoreKVPairs) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_StoreKVPairs.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *StoreKVPairs) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_StoreKVPairs.Merge(m, src)
+}
+func (m *StoreKVPairs) XXX_Size() int {
+	return m.Size()
+}
+func (m *StoreKVPairs) XXX_DiscardUnknown() {
+	xxx_messageInfo_StoreKVPairs.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_StoreKVPairs proto.InternalMessageInfo
+
+func (m *StoreKVPairs) GetPairs() []*StoreKVPair {
+	if m != nil {
+		return m.Pairs
+	}
+	return nil
+}
+
+func (m *StoreKVPairs) GetBlockHeight() int64 {
+	if m != nil {
+		return m.BlockHeight
+	}
+	return 0
+}
+
+func (m *StoreKVPairs) GetStoreKey() string {
+	if m != nil {
+		return m.StoreKey
+	}
+	return ""
+}
+
+func (m *StoreKVPairs) GetKeyPrefix() []byte {
+	if m != nil {
+		return m.KeyPrefix
+	}
+	return nil
+}
+
 func init() {
 	proto.RegisterType((*StoreKVPair)(nil), "cosmos.base.store.v1beta1.StoreKVPair")
+	proto.RegisterType((*StoreKVPairs)(nil), "cosmos.base.store.v1beta1.StoreKVPairs")
 }
 
 func init() {
@@ -104,21 +173,27 @@ func init() {
 }
 
 var fileDescriptor_a5d350879fe4fecd = []byte{
-	// 224 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0xd2, 0x4c, 0xce, 0x2f, 0xce,
-	0xcd, 0x2f, 0xd6, 0x4f, 0x4a, 0x2c, 0x4e, 0xd5, 0x2f, 0x2e, 0xc9, 0x2f, 0x4a, 0xd5, 0x2f, 0x33,
-	0x4c, 0x4a, 0x2d, 0x49, 0x34, 0xd4, 0xcf, 0xc9, 0x2c, 0x2e, 0x49, 0xcd, 0xcb, 0xcc, 0x4b, 0xd7,
-	0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x17, 0x92, 0x84, 0x28, 0xd5, 0x03, 0x29, 0xd5, 0x03, 0x2b, 0xd5,
-	0x83, 0x2a, 0x55, 0xca, 0xe2, 0xe2, 0x0e, 0x06, 0x09, 0x78, 0x87, 0x05, 0x24, 0x66, 0x16, 0x09,
-	0x49, 0x73, 0x71, 0x82, 0xe5, 0xe3, 0xb3, 0x53, 0x2b, 0x25, 0x18, 0x15, 0x18, 0x35, 0x38, 0x83,
-	0x38, 0xc0, 0x02, 0xde, 0xa9, 0x95, 0x42, 0x62, 0x5c, 0x6c, 0x29, 0xa9, 0x39, 0xa9, 0x25, 0xa9,
-	0x12, 0x4c, 0x0a, 0x8c, 0x1a, 0x1c, 0x41, 0x50, 0x9e, 0x90, 0x00, 0x17, 0x33, 0x48, 0x39, 0xb3,
-	0x02, 0xa3, 0x06, 0x4f, 0x10, 0x88, 0x29, 0x24, 0xc2, 0xc5, 0x5a, 0x96, 0x98, 0x53, 0x9a, 0x2a,
-	0xc1, 0x02, 0x16, 0x83, 0x70, 0x9c, 0x9c, 0x4e, 0x3c, 0x92, 0x63, 0xbc, 0xf0, 0x48, 0x8e, 0xf1,
-	0xc1, 0x23, 0x39, 0xc6, 0x09, 0x8f, 0xe5, 0x18, 0x2e, 0x3c, 0x96, 0x63, 0xb8, 0xf1, 0x58, 0x8e,
-	0x21, 0x4a, 0x23, 0x3d, 0xb3, 0x24, 0xa3, 0x34, 0x49, 0x2f, 0x39, 0x3f, 0x57, 0x1f, 0xea, 0x2d,
-	0x08, 0xa5, 0x5b, 0x9c, 0x92, 0x0d, 0xf5, 0x5c, 0x49, 0x65, 0x41, 0x6a, 0x71, 0x12, 0x1b, 0xd8,
-	0x47, 0xc6, 0x80, 0x00, 0x00, 0x00, 0xff, 0xff, 0x2b, 0xe0, 0xb3, 0x51, 0xfe, 0x00, 0x00, 0x00,
+	// 309 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x74, 0x91, 0xb1, 0x4e, 0xf3, 0x30,
+	0x10, 0x80, 0xeb, 0x3f, 0x7f, 0xab, 0xd6, 0xc9, 0x80, 0x2c, 0x84, 0x82, 0x10, 0x56, 0xe8, 0x80,
+	0xc2, 0x80, 0xa3, 0xc2, 0xca, 0xd4, 0x09, 0xa9, 0x4b, 0x15, 0x24, 0x06, 0x96, 0x28, 0x49, 0x8f,
+	0xc4, 0x24, 0xad, 0xa3, 0xd8, 0xad, 0xc8, 0x5b, 0xf0, 0x1e, 0xbc, 0x08, 0x63, 0x47, 0x46, 0x94,
+	0xbc, 0x08, 0x8a, 0x93, 0xa1, 0x20, 0x31, 0xf9, 0xee, 0xf3, 0x77, 0xf2, 0x9d, 0x0f, 0x5f, 0xc5,
+	0x42, 0xae, 0x85, 0xf4, 0xa2, 0x50, 0x82, 0x27, 0x95, 0x28, 0xc1, 0xdb, 0xcd, 0x22, 0x50, 0xe1,
+	0xcc, 0xcb, 0xb9, 0x54, 0xb0, 0xe1, 0x9b, 0x84, 0x15, 0xa5, 0x50, 0x82, 0x9c, 0x76, 0x2a, 0x6b,
+	0x55, 0xa6, 0x55, 0xd6, 0xab, 0xd3, 0x17, 0x6c, 0x3e, 0xb4, 0x60, 0xf1, 0xb8, 0x0c, 0x79, 0x49,
+	0xce, 0xf0, 0x44, 0xdf, 0x07, 0x19, 0x54, 0x36, 0x72, 0x90, 0x3b, 0xf1, 0xc7, 0x1a, 0x2c, 0xa0,
+	0x22, 0x27, 0x78, 0xb4, 0x82, 0x1c, 0x14, 0xd8, 0xff, 0x1c, 0xe4, 0x8e, 0xfd, 0x3e, 0x23, 0x47,
+	0xd8, 0x68, 0x75, 0xc3, 0x41, 0xae, 0xe5, 0xb7, 0x21, 0x39, 0xc6, 0xc3, 0x5d, 0x98, 0x6f, 0xc1,
+	0xfe, 0xaf, 0x59, 0x97, 0x4c, 0xdf, 0x11, 0xb6, 0x0e, 0x1e, 0x93, 0xe4, 0x0e, 0x0f, 0x8b, 0x36,
+	0xb0, 0x91, 0x63, 0xb8, 0xe6, 0xcd, 0x25, 0xfb, 0xb3, 0x4f, 0x76, 0x50, 0xe7, 0x77, 0x45, 0xe4,
+	0x02, 0x5b, 0x51, 0x2e, 0xe2, 0x2c, 0x48, 0x81, 0x27, 0xa9, 0xd2, 0x4d, 0x19, 0xbe, 0xa9, 0xd9,
+	0xbd, 0x46, 0x3f, 0xc7, 0x31, 0x7e, 0x8d, 0x73, 0x8e, 0x71, 0x06, 0x55, 0x50, 0x94, 0xf0, 0xcc,
+	0x5f, 0xfb, 0x4e, 0x27, 0x19, 0x54, 0x4b, 0x0d, 0xe6, 0xf3, 0x8f, 0x9a, 0xa2, 0x7d, 0x4d, 0xd1,
+	0x57, 0x4d, 0xd1, 0x5b, 0x43, 0x07, 0xfb, 0x86, 0x0e, 0x3e, 0x1b, 0x3a, 0x78, 0x72, 0x13, 0xae,
+	0xd2, 0x6d, 0xc4, 0x62, 0xb1, 0xf6, 0xfa, 0x25, 0x74, 0xc7, 0xb5, 0x5c, 0x65, 0xfd, 0x2a, 0x54,
+	0x55, 0x80, 0x8c, 0x46, 0xfa, 0xff, 0x6f, 0xbf, 0x03, 0x00, 0x00, 0xff, 0xff, 0x07, 0x4c, 0x25,
+	0x5a, 0xac, 0x01, 0x00, 0x00,
 }
 
 func (m *StoreKVPair) Marshal() (dAtA []byte, err error) {
@@ -175,6 +250,62 @@ func (m *StoreKVPair) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *StoreKVPairs) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *StoreKVPairs) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *StoreKVPairs) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.KeyPrefix) > 0 {
+		i -= len(m.KeyPrefix)
+		copy(dAtA[i:], m.KeyPrefix)
+		i = encodeVarintListening(dAtA, i, uint64(len(m.KeyPrefix)))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.StoreKey) > 0 {
+		i -= len(m.StoreKey)
+		copy(dAtA[i:], m.StoreKey)
+		i = encodeVarintListening(dAtA, i, uint64(len(m.StoreKey)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if m.BlockHeight != 0 {
+		i = encodeVarintListening(dAtA, i, uint64(m.BlockHeight))
+		i--
+		dAtA[i] = 0x10
+	}
+	if len(m.Pairs) > 0 {
+		for iNdEx := len(m.Pairs) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Pairs[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintListening(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintListening(dAtA []byte, offset int, v uint64) int {
 	offset -= sovListening(v)
 	base := offset
@@ -204,6 +335,32 @@ func (m *StoreKVPair) Size() (n int) {
 		n += 1 + l + sovListening(uint64(l))
 	}
 	l = len(m.Value)
+	if l > 0 {
+		n += 1 + l + sovListening(uint64(l))
+	}
+	return n
+}
+
+func (m *StoreKVPairs) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if len(m.Pairs) > 0 {
+		for _, e := range m.Pairs {
+			l = e.Size()
+			n += 1 + l + sovListening(uint64(l))
+		}
+	}
+	if m.BlockHeight != 0 {
+		n += 1 + sovListening(uint64(m.BlockHeight))
+	}
+	l = len(m.StoreKey)
+	if l > 0 {
+		n += 1 + l + sovListening(uint64(l))
+	}
+	l = len(m.KeyPrefix)
 	if l > 0 {
 		n += 1 + l + sovListening(uint64(l))
 	}
@@ -363,6 +520,175 @@ func (m *StoreKVPair) Unmarshal(dAtA []byte) error {
 			m.Value = append(m.Value[:0], dAtA[iNdEx:postIndex]...)
 			if m.Value == nil {
 				m.Value = []byte{}
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipListening(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthListening
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *StoreKVPairs) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowListening
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: StoreKVPairs: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: StoreKVPairs: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Pairs", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowListening
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthListening
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthListening
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Pairs = append(m.Pairs, &StoreKVPair{})
+			if err := m.Pairs[len(m.Pairs)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field BlockHeight", wireType)
+			}
+			m.BlockHeight = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowListening
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.BlockHeight |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field StoreKey", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowListening
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthListening
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthListening
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.StoreKey = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field KeyPrefix", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowListening
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthListening
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthListening
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.KeyPrefix = append(m.KeyPrefix[:0], dAtA[iNdEx:postIndex]...)
+			if m.KeyPrefix == nil {
+				m.KeyPrefix = []byte{}
 			}
 			iNdEx = postIndex
 		default:

--- a/store/types/listening_test.go
+++ b/store/types/listening_test.go
@@ -1,66 +1,42 @@
 package types
 
 import (
-	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/cosmos/cosmos-sdk/codec"
-	"github.com/cosmos/cosmos-sdk/codec/types"
 )
 
 func TestNewStoreKVPairWriteListener(t *testing.T) {
-	testWriter := new(bytes.Buffer)
-	interfaceRegistry := types.NewInterfaceRegistry()
-	testMarshaller := codec.NewProtoCodec(interfaceRegistry)
-
-	wl := NewStoreKVPairWriteListener(testWriter, testMarshaller)
-
-	require.IsType(t, &StoreKVPairWriteListener{}, wl)
-	require.Equal(t, testWriter, wl.writer)
-	require.Equal(t, testMarshaller, wl.marshaller)
+	listener := NewMemoryListener()
+	require.IsType(t, &MemoryListener{}, listener)
 }
 
 func TestOnWrite(t *testing.T) {
-	testWriter := new(bytes.Buffer)
-	interfaceRegistry := types.NewInterfaceRegistry()
-	testMarshaller := codec.NewProtoCodec(interfaceRegistry)
-
-	wl := NewStoreKVPairWriteListener(testWriter, testMarshaller)
+	listener := NewMemoryListener()
 
 	testStoreKey := NewKVStoreKey("test_key")
 	testKey := []byte("testing123")
 	testValue := []byte("testing321")
 
 	// test set
-	err := wl.OnWrite(testStoreKey, testKey, testValue, false)
-	require.Nil(t, err)
-
-	outputBytes := testWriter.Bytes()
-	outputKVPair := new(StoreKVPair)
+	listener.OnWrite(testStoreKey, testKey, testValue, false)
+	outputKVPair := listener.PopStateCache()[0]
 	expectedOutputKVPair := &StoreKVPair{
 		Key:      testKey,
 		Value:    testValue,
 		StoreKey: testStoreKey.Name(),
 		Delete:   false,
 	}
-	testMarshaller.UnmarshalLengthPrefixed(outputBytes, outputKVPair)
 	require.EqualValues(t, expectedOutputKVPair, outputKVPair)
-	testWriter.Reset()
 
 	// test delete
-	err = wl.OnWrite(testStoreKey, testKey, testValue, true)
-	require.Nil(t, err)
-
-	outputBytes = testWriter.Bytes()
-	outputKVPair = new(StoreKVPair)
+	listener.OnWrite(testStoreKey, testKey, testValue, true)
+	outputKVPair = listener.PopStateCache()[0]
 	expectedOutputKVPair = &StoreKVPair{
 		Key:      testKey,
 		Value:    testValue,
 		StoreKey: testStoreKey.Name(),
 		Delete:   true,
 	}
-	testMarshaller.UnmarshalLengthPrefixed(outputBytes, outputKVPair)
 	require.EqualValues(t, expectedOutputKVPair, outputKVPair)
 }

--- a/store/types/store.go
+++ b/store/types/store.go
@@ -132,13 +132,6 @@ type MultiStore interface {
 	// implied that the caller should update the context when necessary between
 	// tracing operations. The modified MultiStore is returned.
 	SetTracingContext(TraceContext) MultiStore
-
-	// ListeningEnabled returns if listening is enabled for the KVStore belonging the provided StoreKey
-	ListeningEnabled(key StoreKey) bool
-
-	// AddListeners adds WriteListeners for the KVStore belonging to the provided StoreKey
-	// It appends the listeners to a current set, if one already exists
-	AddListeners(key StoreKey, listeners []WriteListener)
 }
 
 // From MultiStore.CacheMultiStore()....
@@ -194,6 +187,15 @@ type CommitMultiStore interface {
 
 	// SetIAVLCacheSize sets the cache size of the IAVL tree.
 	SetIAVLCacheSize(size int)
+
+	// ListeningEnabled returns if listening is enabled for the KVStore belonging the provided StoreKey
+	ListeningEnabled(key StoreKey) bool
+
+	// AddListeners adds a listener for the KVStore belonging to the provided StoreKey
+	AddListeners(keys []StoreKey)
+
+	// PopStateCache returns the accumulated state change messages from the CommitMultiStore
+	PopStateCache() []*StoreKVPair
 }
 
 //---------subsp-------------------------------
@@ -266,9 +268,6 @@ type CacheWrap interface {
 
 	// CacheWrapWithTrace recursively wraps again with tracing enabled.
 	CacheWrapWithTrace(w io.Writer, tc TraceContext) CacheWrap
-
-	// CacheWrapWithListeners recursively wraps again with listening enabled
-	CacheWrapWithListeners(storeKey StoreKey, listeners []WriteListener) CacheWrap
 }
 
 type CacheWrapper interface {
@@ -277,9 +276,6 @@ type CacheWrapper interface {
 
 	// CacheWrapWithTrace branches a store with tracing enabled.
 	CacheWrapWithTrace(w io.Writer, tc TraceContext) CacheWrap
-
-	// CacheWrapWithListeners recursively wraps again with listening enabled
-	CacheWrapWithListeners(storeKey StoreKey, listeners []WriteListener) CacheWrap
 }
 
 func (cid CommitID) IsZero() bool {

--- a/store/types/streaming.go
+++ b/store/types/streaming.go
@@ -1,0 +1,32 @@
+package types
+
+import (
+	"context"
+
+	abci "github.com/tendermint/tendermint/abci/types"
+)
+
+// ABCIListener is the interface that we're exposing as a streaming service.
+// It hooks into the ABCI message processing of the BaseApp.
+// The error results are propagated to consensus state machine,
+// if you don't want to affect consensus, handle the errors internally and always return `nil` in these APIs.
+type ABCIListener interface {
+	// ListenBeginBlock updates the streaming service with the latest BeginBlock messages
+	ListenBeginBlock(ctx context.Context, req abci.RequestBeginBlock, res abci.ResponseBeginBlock) error
+	// ListenEndBlock updates the steaming service with the latest EndBlock messages
+	ListenEndBlock(ctx context.Context, req abci.RequestEndBlock, res abci.ResponseEndBlock) error
+	// ListenDeliverTx updates the steaming service with the latest DeliverTx messages
+	ListenDeliverTx(ctx context.Context, req abci.RequestDeliverTx, res abci.ResponseDeliverTx) error
+	// ListenCommit updates the steaming service with the latest Commit messages and state changes
+	ListenCommit(ctx context.Context, res abci.ResponseCommit, changeSet []*StoreKVPair) error
+}
+
+// StreamingManager is the struct that maintains a list of ABCIListeners and configuration settings.
+type StreamingManager struct {
+	// ABCIListeners for hooking into the ABCI message processing of the BaseApp
+	// and exposing the requests and responses to external consumers
+	ABCIListeners []ABCIListener
+
+	// StopNodeOnErr halts the node when ABCI streaming service listening results in an error.
+	StopNodeOnErr bool
+}

--- a/x/auth/tx/builder.go
+++ b/x/auth/tx/builder.go
@@ -10,7 +10,6 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/types/tx"
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
-	"github.com/cosmos/cosmos-sdk/x/auth/ante"
 	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
 )
 
@@ -31,10 +30,11 @@ type wrapper struct {
 }
 
 var (
-	_ authsigning.Tx             = &wrapper{}
-	_ client.TxBuilder           = &wrapper{}
-	_ ante.HasExtensionOptionsTx = &wrapper{}
-	_ ExtensionOptionsTxBuilder  = &wrapper{}
+	_ authsigning.Tx   = &wrapper{}
+	_ client.TxBuilder = &wrapper{}
+	// prevent import cycle
+	//_ ante.HasExtensionOptionsTx = &wrapper{}
+	_ ExtensionOptionsTxBuilder = &wrapper{}
 )
 
 // ExtensionOptionsTxBuilder defines a TxBuilder that can also set extensions.


### PR DESCRIPTION
- inscrutable counter tests are failing, but everything else seems ok
- use flag to panic on failure

delete dead ref

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

> Add a description of the overall background and high-level changes that this PR introduces

*(E.g.: This pull request improves documentation of area A by adding ....*


## Brief Changelog

*(for example:)*
 
  - *The metadata is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *Daemons retrieve the RPC data from the blob cache*


## Testing and Verifying

*(Please pick one of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added unit test that validates ...*
  - *Added integration tests for end-to-end deployment with ...*
  - *Extended integration test for ...*
  - *Manually verified the change by ...*

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)
