### PR TITLE
Making the timestamp available to the rms on commits

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -318,6 +318,12 @@ func (app *BaseApp) Commit() (res abci.ResponseCommit) {
 	// The write to the DeliverTx state writes all state transitions to the root
 	// MultiStore (app.cms) so when Commit() is called is persists those values.
 	app.deliverState.ms.Write()
+
+	rms, ok := app.cms.(*rootmulti.Store)
+	if ok {
+		rms.SetCommitHeader(header)
+	}
+
 	commitID := app.cms.Commit()
 
 	// Reset the Check state to the latest committed.

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -2,6 +2,7 @@ package rootmulti
 
 import (
 	"fmt"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	"io"
 	"math"
 	"sort"
@@ -69,7 +70,8 @@ type Store struct {
 
 	interBlockCache types.MultiStorePersistentCache
 
-	listeners map[types.StoreKey][]types.WriteListener
+	listeners    map[types.StoreKey][]types.WriteListener
+	commitHeader tmproto.Header
 }
 
 var (
@@ -418,6 +420,7 @@ func (rs *Store) Commit() types.CommitID {
 	}
 
 	newCommitInfo := rs.commitStores(version, rs.stores)
+	newCommitInfo.Timestamp = rs.commitHeader.Time
 	rs.updateLatestCommitInfo(newCommitInfo, version)
 
 	err := rs.handlePruning(version)
@@ -434,6 +437,11 @@ func (rs *Store) Commit() types.CommitID {
 		Version: version,
 		Hash:    hash,
 	}
+}
+
+// SetCommitHeader sets the commit block header of the store.
+func (rs *Store) SetCommitHeader(h tmproto.Header) {
+	rs.commitHeader = h
 }
 
 // CacheWrap implements CacheWrapper/Store/CommitStore.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Ref: https://github.com/osmosis-labs/osmosis/issues/5960

## What is the purpose of the change

Historical wasm queries depend on the block timestamp being available on the queryContext (https://github.com/osmosis-labs/wasmd/blob/master/x/wasm/types/types.go#L273-L277). The timestamp is added to the context in https://github.com/osmosis-labs/cosmos-sdk/blob/osmosis-main/baseapp/abci.go#L685-L693, but that doesn't work on 0.45 because the timestamp is never stored.

This PR fixes that. 

## Brief Changelog

Store the timestamp in the RootMultiStore like it's done in the latest version of the SDK

## Testing and Verifying
all tests should pass

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
  - How is the feature or change documented? (not applicable   /   specification (`x/<module>/spec/`)  /  [Osmosis docs repo](https://github.com/osmosis-labs/docs)   /   not documented)
