### PR TITLE
feat: split param getter and unmarshal

### DIFF
--- a/x/consensus/keeper/keeper.go
+++ b/x/consensus/keeper/keeper.go
@@ -56,3 +56,17 @@ func (k *Keeper) Set(ctx sdk.Context, cp *tmproto.ConsensusParams) {
 	store := ctx.KVStore(k.storeKey)
 	store.Set(types.ParamStoreKeyConsensusParams, k.cdc.MustMarshal(cp))
 }
+
+func (k *Keeper) GetParamsNoUnmarshal(ctx sdk.Context) []byte {
+	store := ctx.KVStore(k.storeKey)
+	return store.Get(types.ParamStoreKeyConsensusParams)
+}
+
+func (k *Keeper) UnmarshalParamBytes(ctx sdk.Context, bz []byte) (*tmproto.ConsensusParams, error) {
+	cp := &tmproto.ConsensusParams{}
+	if err := k.cdc.Unmarshal(bz, cp); err != nil {
+		return nil, err
+	}
+
+	return cp, nil
+}


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: #XXXX

Small perf change, allows EIP to get param without unmarshalling, allowing it to cache value
