### PR TITLE
feat: config option to log gRPC queries

### DIFF
--- a/baseapp/grpcserver.go
+++ b/baseapp/grpcserver.go
@@ -2,6 +2,7 @@ package baseapp
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 
 	gogogrpc "github.com/cosmos/gogoproto/grpc"
@@ -21,7 +22,7 @@ import (
 func (app *BaseApp) GRPCQueryRouter() *GRPCQueryRouter { return app.grpcQueryRouter }
 
 // RegisterGRPCServer registers gRPC services directly with the gRPC server.
-func (app *BaseApp) RegisterGRPCServer(server gogogrpc.Server) {
+func (app *BaseApp) RegisterGRPCServer(server gogogrpc.Server, logQueries bool) {
 	// Define an interceptor for all gRPC queries: this interceptor will create
 	// a new sdk.Context, and pass it into the query handler.
 	interceptor := func(grpcCtx context.Context, req interface{}, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
@@ -63,6 +64,10 @@ func (app *BaseApp) RegisterGRPCServer(server gogogrpc.Server) {
 		md = metadata.Pairs(grpctypes.GRPCBlockHeightHeader, strconv.FormatInt(height, 10))
 		if err = grpc.SetHeader(grpcCtx, md); err != nil {
 			app.logger.Error("failed to set gRPC header", "err", err)
+		}
+
+		if logQueries {
+			app.logger.Info("gRPC query received of type: " + fmt.Sprintf("%#v", req))
 		}
 
 		return handler(grpcCtx, req)

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -34,6 +34,10 @@ const (
 	// bytes the server can send.
 	DefaultGRPCMaxSendMsgSize = math.MaxInt32
 
+	// DefaultLogQueries defines the default value for the log_queries parameter.
+	// Should be set to false unless debugging.
+	DefaultLogQueries = false
+
 	// FileStreamer defines the store streaming type for file streaming.
 	FileStreamer = "file"
 )
@@ -322,7 +326,7 @@ func DefaultConfig() *Config {
 			Address:        DefaultGRPCAddress,
 			MaxRecvMsgSize: DefaultGRPCMaxRecvMsgSize,
 			MaxSendMsgSize: DefaultGRPCMaxSendMsgSize,
-			LogQueries:     false,
+			LogQueries:     DefaultLogQueries,
 		},
 		Rosetta: RosettaConfig{
 			Enable:              false,

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -177,6 +177,9 @@ type GRPCConfig struct {
 	// MaxSendMsgSize defines the max message size in bytes the server can send.
 	// The default value is math.MaxInt32.
 	MaxSendMsgSize int `mapstructure:"max-send-msg-size"`
+
+	// LogQueries logs every gRPC query to the console as an info log.
+	LogQueries bool `mapstructure:"log-queries"`
 }
 
 // GRPCWebConfig defines configuration for the gRPC-web server.
@@ -319,6 +322,7 @@ func DefaultConfig() *Config {
 			Address:        DefaultGRPCAddress,
 			MaxRecvMsgSize: DefaultGRPCMaxRecvMsgSize,
 			MaxSendMsgSize: DefaultGRPCMaxSendMsgSize,
+			LogQueries:     false,
 		},
 		Rosetta: RosettaConfig{
 			Enable:              false,

--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -207,6 +207,10 @@ max-recv-msg-size = "{{ .GRPC.MaxRecvMsgSize }}"
 # The default value is math.MaxInt32.
 max-send-msg-size = "{{ .GRPC.MaxSendMsgSize }}"
 
+# LogQueries if enabled will print an info log stating what query type
+# was submitted to this node on every submission.
+log-queries = "{{ .GRPC.LogQueries }}"
+
 ###############################################################################
 ###                        gRPC Web Configuration                           ###
 ###############################################################################

--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -207,8 +207,9 @@ max-recv-msg-size = "{{ .GRPC.MaxRecvMsgSize }}"
 # The default value is math.MaxInt32.
 max-send-msg-size = "{{ .GRPC.MaxSendMsgSize }}"
 
-# LogQueries if enabled will print an info log stating what query type
-# was submitted to this node on every submission.
+# LogQueries if enabled will print an info log containing the query request
+# that was submitted to this node on every submission.
+# This is useful strictly for debugging purposes and should be disabled otherwise.
 log-queries = "{{ .GRPC.LogQueries }}"
 
 ###############################################################################

--- a/server/grpc/server.go
+++ b/server/grpc/server.go
@@ -35,7 +35,7 @@ func StartGRPCServer(clientCtx client.Context, app types.Application, cfg config
 		grpc.MaxRecvMsgSize(maxRecvMsgSize),
 	)
 
-	app.RegisterGRPCServer(grpcSrv)
+	app.RegisterGRPCServer(grpcSrv, cfg.LogQueries)
 
 	// Reflection allows consumers to build dynamic clients that can write to any
 	// Cosmos SDK application without relying on application packages at compile

--- a/server/types/app.go
+++ b/server/types/app.go
@@ -46,7 +46,7 @@ type (
 
 		// RegisterGRPCServer registers gRPC services directly with the gRPC
 		// server.
-		RegisterGRPCServer(grpc.Server)
+		RegisterGRPCServer(grpc.Server, bool)
 
 		// RegisterTxService registers the gRPC Query service for tx (such as tx
 		// simulation, fetching txs by hash...).


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

This PR introduces a "log-queries" boolean option field to the gRPC section of app.toml. If enabled, a log resembling the following will be logged to the console at the receipt of every gRPC query.

![Screenshot 2024-01-13 at 7 16 16 PM](https://github.com/osmosis-labs/cosmos-sdk/assets/40078083/753b7e77-8f03-4790-84a7-a0cd444d7f7a)

This will help us better zero in on what gRPC queries are causing non-determinism in gas used results.

After merge, this needs to be cherry picked to osmo-v22/v0.47.5, as well as upstreamed.
