### PR TITLE
feat: skip testnetify confirmation

### DIFF
--- a/server/start.go
+++ b/server/start.go
@@ -654,15 +654,20 @@ you want to test the upgrade handler itself.
 			newChainID := args[0]
 			newOperatorAddress := args[1]
 
-			// Confirmation prompt to prevent accidental modification of state.
-			reader := bufio.NewReader(os.Stdin)
-			fmt.Println("This operation will modify state in your data folder and cannot be undone. Do you want to continue? (y/n)")
-			text, _ := reader.ReadString('\n')
-			response := strings.TrimSpace(strings.ToLower(text))
-			if response != "y" && response != "yes" {
-				fmt.Println("Operation canceled.")
-				return nil
+			skipConfirmation, _ := cmd.Flags().GetBool("skip-confirmation")
+
+			if !skipConfirmation {
+				// Confirmation prompt to prevent accidental modification of state.
+				reader := bufio.NewReader(os.Stdin)
+				fmt.Println("This operation will modify state in your data folder and cannot be undone. Do you want to continue? (y/n)")
+				text, _ := reader.ReadString('\n')
+				response := strings.TrimSpace(strings.ToLower(text))
+				if response != "y" && response != "yes" {
+					fmt.Println("Operation canceled.")
+					return nil
+				}
 			}
+
 			serverCtx.Viper.Set(KeyIsTestnet, true)
 			serverCtx.Viper.Set(KeyNewChainID, newChainID)
 			serverCtx.Viper.Set(KeyNewOpAddr, newOperatorAddress)
@@ -673,6 +678,7 @@ you want to test the upgrade handler itself.
 
 	addStartNodeFlags(cmd, defaultNodeHome)
 	cmd.Flags().String(KeyTriggerTestnetUpgrade, "", "If set (example: \"v21\"), triggers the v21 upgrade handler to run on the first block of the testnet")
+	cmd.Flags().Bool("skip-confirmation", false, "Skip the confirmation prompt")
 	return cmd
 }
 


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Adds "skip-confirmation" flag that allows infra/devops to automate testnet creation.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
