### PR TITLE
feat: distribute every 50 blocks

### DIFF
--- a/tests/e2e/distribution/suite.go
+++ b/tests/e2e/distribution/suite.go
@@ -40,6 +40,8 @@ func NewE2ETestSuite(cfg network.Config) *E2ETestSuite {
 func (s *E2ETestSuite) SetupSuite() {
 	s.T().Log("setting up e2e test suite")
 
+	// We distribute rewards every block here since we test the delayed distribution
+	// in another test.
 	distr.BlockMultipleToDistributeRewards = 1
 
 	cfg := network.DefaultConfig(simapp.NewTestNetworkFixture)

--- a/tests/e2e/distribution/suite.go
+++ b/tests/e2e/distribution/suite.go
@@ -15,6 +15,7 @@ import (
 	clitestutil "github.com/cosmos/cosmos-sdk/testutil/cli"
 	"github.com/cosmos/cosmos-sdk/testutil/network"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	distr "github.com/cosmos/cosmos-sdk/x/distribution"
 	"github.com/cosmos/cosmos-sdk/x/distribution/client/cli"
 	distrclitestutil "github.com/cosmos/cosmos-sdk/x/distribution/client/testutil"
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
@@ -38,6 +39,8 @@ func NewE2ETestSuite(cfg network.Config) *E2ETestSuite {
 // these state changes to be present in other tests.
 func (s *E2ETestSuite) SetupSuite() {
 	s.T().Log("setting up e2e test suite")
+
+	distr.BlockMultipleToDistributeRewards = 1
 
 	cfg := network.DefaultConfig(simapp.NewTestNetworkFixture)
 	cfg.NumValidators = 1

--- a/tests/integration/distribution/keeper/allocation_test.go
+++ b/tests/integration/distribution/keeper/allocation_test.go
@@ -72,6 +72,10 @@ func TestAllocateTokensToManyValidators(t *testing.T) {
 		stakingKeeper *stakingkeeper.Keeper
 	)
 
+	// set distribute to every block for first test.
+	// we test the delayed distribution in the next test.
+	dist.BlockMultipleToDistributeRewards = 1
+
 	app, err := simtestutil.Setup(testutil.AppConfig,
 		&accountKeeper,
 		&bankKeeper,
@@ -163,6 +167,7 @@ func TestAllocateTokensToManyValidators(t *testing.T) {
 	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDecWithPrec(490, 1)}}, firstValidator1CurrentRewards)
 
 	// test that the block height triggers the distribution
+	dist.BlockMultipleToDistributeRewards = 50
 
 	// block height is not a multiple, should not trigger allocation (no change in rewards)
 	ctx = ctx.WithBlockHeight(dist.BlockMultipleToDistributeRewards - 1)

--- a/tests/integration/distribution/keeper/allocation_test.go
+++ b/tests/integration/distribution/keeper/allocation_test.go
@@ -178,7 +178,7 @@ func TestAllocateTokensToManyValidators(t *testing.T) {
 	require.Equal(t, firstValidator0CurrentRewards, distrKeeper.GetValidatorCurrentRewards(ctx, valAddrs[0]).Rewards)
 	require.Equal(t, firstValidator1CurrentRewards, distrKeeper.GetValidatorCurrentRewards(ctx, valAddrs[1]).Rewards)
 
-	// block height is not a multiple, should trigger allocation
+	// block height is a multiple, should trigger allocation
 	ctx = ctx.WithBlockHeight(dist.BlockMultipleToDistributeRewards)
 
 	feesCollectedInt := bankKeeper.GetAllBalances(ctx, feeCollector.GetAddress())

--- a/tests/integration/distribution/keeper/msg_server_test.go
+++ b/tests/integration/distribution/keeper/msg_server_test.go
@@ -2,6 +2,7 @@ package keeper_test
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	banktestutil "github.com/cosmos/cosmos-sdk/x/bank/testutil"
 	"github.com/cosmos/cosmos-sdk/x/distribution/types"
 )
 
@@ -159,7 +160,13 @@ func (s *KeeperTestSuite) TestCommunityPoolSpend() {
 	for _, tc := range testCases {
 		tc := tc
 		s.Run(tc.name, func() {
-			_, err := s.msgServer.CommunityPoolSpend(s.ctx, tc.input)
+			amount := sdk.NewCoins(sdk.NewInt64Coin("stake", 100))
+			s.Require().NoError(banktestutil.FundAccount(s.bankKeeper, s.ctx, s.addrs[0], amount))
+
+			err := s.distrKeeper.FundCommunityPool(s.ctx, amount, s.addrs[0])
+			s.Require().Nil(err)
+
+			_, err = s.msgServer.CommunityPoolSpend(s.ctx, tc.input)
 
 			if tc.expErr {
 				s.Require().Error(err)

--- a/x/distribution/abci.go
+++ b/x/distribution/abci.go
@@ -23,7 +23,7 @@ func BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock, k keeper.Keeper) 
 	blockHeight := ctx.BlockHeight()
 	// only allocate rewards if the block height is greater than 1
 	// and for every multiple of 10 blocks for performance reasons.
-	if blockHeight > 1 && blockHeight%BlockMultipleToDistributeRewards == 0 {
+	if (blockHeight > 1 && blockHeight%BlockMultipleToDistributeRewards == 0) || blockHeight == 2 {
 		// determine the total power signing the block
 		var previousTotalPower int64
 		for _, voteInfo := range req.LastCommitInfo.GetVotes() {

--- a/x/distribution/abci.go
+++ b/x/distribution/abci.go
@@ -21,7 +21,7 @@ func BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock, k keeper.Keeper) 
 	blockHeight := ctx.BlockHeight()
 	// only allocate rewards if the block height is greater than 1
 	// and only allocate rewards for every multiple of 10 blocks for performance reasons.
-	if blockHeight > 1 && blockHeight%10 == 0 {
+	if (blockHeight > 1 && blockHeight%10 == 0) || blockHeight == 2 {
 		// determine the total power signing the block
 		var previousTotalPower int64
 		for _, voteInfo := range req.LastCommitInfo.GetVotes() {

--- a/x/distribution/abci.go
+++ b/x/distribution/abci.go
@@ -11,7 +11,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/distribution/types"
 )
 
-var BlockMultipleToDistributeRewards = int64(10)
+var BlockMultipleToDistributeRewards = int64(20)
 
 // BeginBlocker sets the proposer for determining distribution during endblock
 // and distribute rewards for the previous block.

--- a/x/distribution/abci.go
+++ b/x/distribution/abci.go
@@ -23,7 +23,7 @@ func BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock, k keeper.Keeper) 
 	blockHeight := ctx.BlockHeight()
 	// only allocate rewards if the block height is greater than 1
 	// and for every multiple of 10 blocks for performance reasons.
-	if (blockHeight > 1 && blockHeight%BlockMultipleToDistributeRewards == 0) || blockHeight == 2 {
+	if blockHeight > 1 && blockHeight%BlockMultipleToDistributeRewards == 0 {
 		// determine the total power signing the block
 		var previousTotalPower int64
 		for _, voteInfo := range req.LastCommitInfo.GetVotes() {

--- a/x/distribution/abci.go
+++ b/x/distribution/abci.go
@@ -11,6 +11,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/distribution/types"
 )
 
+var BlockMultipleToDistributeRewards = int64(10)
+
 // BeginBlocker sets the proposer for determining distribution during endblock
 // and distribute rewards for the previous block.
 func BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock, k keeper.Keeper) {
@@ -20,8 +22,9 @@ func BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock, k keeper.Keeper) 
 	// ref https://github.com/cosmos/cosmos-sdk/issues/3095
 	blockHeight := ctx.BlockHeight()
 	// only allocate rewards if the block height is greater than 1
-	// and only allocate rewards for every multiple of 10 blocks for performance reasons.
-	if (blockHeight > 1 && blockHeight%10 == 0) || blockHeight == 2 {
+	// and for every multiple of 10 blocks for performance reasons.
+	// We special case blockHeight 2 to allow test cases to still be valid.
+	if (blockHeight > 1 && blockHeight%BlockMultipleToDistributeRewards == 0) || blockHeight == 2 {
 		// determine the total power signing the block
 		var previousTotalPower int64
 		for _, voteInfo := range req.LastCommitInfo.GetVotes() {

--- a/x/distribution/abci.go
+++ b/x/distribution/abci.go
@@ -16,18 +16,18 @@ import (
 func BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock, k keeper.Keeper) {
 	defer telemetry.ModuleMeasureSince(types.ModuleName, time.Now(), telemetry.MetricKeyBeginBlocker)
 
-	// determine the total power signing the block
-	var previousTotalPower int64
-	for _, voteInfo := range req.LastCommitInfo.GetVotes() {
-		previousTotalPower += voteInfo.Validator.Power
-	}
-
 	// TODO this is Tendermint-dependent
 	// ref https://github.com/cosmos/cosmos-sdk/issues/3095
 	blockHeight := ctx.BlockHeight()
 	// only allocate rewards if the block height is greater than 1
 	// and only allocate rewards for every multiple of 10 blocks for performance reasons.
 	if blockHeight > 1 && blockHeight%10 == 0 {
+		// determine the total power signing the block
+		var previousTotalPower int64
+		for _, voteInfo := range req.LastCommitInfo.GetVotes() {
+			previousTotalPower += voteInfo.Validator.Power
+		}
+
 		k.AllocateTokens(ctx, previousTotalPower, req.LastCommitInfo.GetVotes())
 	}
 

--- a/x/distribution/abci.go
+++ b/x/distribution/abci.go
@@ -22,7 +22,7 @@ func BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock, k keeper.Keeper) 
 	// ref https://github.com/cosmos/cosmos-sdk/issues/3095
 	blockHeight := ctx.BlockHeight()
 	// only allocate rewards if the block height is greater than 1
-	// and for every multiple of 10 blocks for performance reasons.
+	// and for every multiple of 20 blocks for performance reasons.
 	if blockHeight > 1 && blockHeight%BlockMultipleToDistributeRewards == 0 {
 		// determine the total power signing the block
 		var previousTotalPower int64

--- a/x/distribution/abci.go
+++ b/x/distribution/abci.go
@@ -24,7 +24,10 @@ func BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock, k keeper.Keeper) 
 
 	// TODO this is Tendermint-dependent
 	// ref https://github.com/cosmos/cosmos-sdk/issues/3095
-	if ctx.BlockHeight() > 1 {
+	blockHeight := ctx.BlockHeight()
+	// only allocate rewards if the block height is greater than 1
+	// and only allocate rewards for every multiple of 10 blocks for performance reasons.
+	if blockHeight > 1 && blockHeight%10 == 0 {
 		k.AllocateTokens(ctx, previousTotalPower, req.LastCommitInfo.GetVotes())
 	}
 

--- a/x/distribution/abci.go
+++ b/x/distribution/abci.go
@@ -23,8 +23,7 @@ func BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock, k keeper.Keeper) 
 	blockHeight := ctx.BlockHeight()
 	// only allocate rewards if the block height is greater than 1
 	// and for every multiple of 10 blocks for performance reasons.
-	// We special case blockHeight 2 to allow test cases to still be valid.
-	if (blockHeight > 1 && blockHeight%BlockMultipleToDistributeRewards == 0) || blockHeight == 2 {
+	if blockHeight > 1 && blockHeight%BlockMultipleToDistributeRewards == 0 {
 		// determine the total power signing the block
 		var previousTotalPower int64
 		for _, voteInfo := range req.LastCommitInfo.GetVotes() {

--- a/x/distribution/abci.go
+++ b/x/distribution/abci.go
@@ -11,7 +11,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/distribution/types"
 )
 
-var BlockMultipleToDistributeRewards = int64(20)
+var BlockMultipleToDistributeRewards = int64(50)
 
 // BeginBlocker sets the proposer for determining distribution during endblock
 // and distribute rewards for the previous block.
@@ -22,7 +22,7 @@ func BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock, k keeper.Keeper) 
 	// ref https://github.com/cosmos/cosmos-sdk/issues/3095
 	blockHeight := ctx.BlockHeight()
 	// only allocate rewards if the block height is greater than 1
-	// and for every multiple of 20 blocks for performance reasons.
+	// and for every multiple of 50 blocks for performance reasons.
 	if blockHeight > 1 && blockHeight%BlockMultipleToDistributeRewards == 0 {
 		// determine the total power signing the block
 		var previousTotalPower int64


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: #XXXX

The distribution module runs distribution logic every block. This is unnecessary overhead. We can hold off this logic to instead run every 50 blocks.
