### PR TITLE
fix: edge case in-place-testnet states

### DIFF
--- a/server/start.go
+++ b/server/start.go
@@ -742,7 +742,9 @@ func testnetify(ctx *Context, home string, testnetAppCreator types.AppCreator, d
 	// Depending on how the node was stopped, the application height can differ from the blockStore height.
 	// This height difference changes how we go about modifying the state.
 	clientCreator := proxy.NewLocalClientCreator(testnetApp)
-	metrics := node.DefaultMetricsProvider(config.Instrumentation)
+	// This metrics provider is just for the proxy app, so we can utilize a nil input.
+	// If prometheus is enabled and we don't use a nil input, this panics.
+	metrics := node.DefaultMetricsProvider(nil)
 	_, _, _, _, proxyMetrics := metrics(genDoc.ChainID) //nolint:dogsled
 	proxyApp := proxy.NewAppConns(clientCreator, proxyMetrics)
 	if err := proxyApp.Start(); err != nil {

--- a/server/start.go
+++ b/server/start.go
@@ -760,30 +760,24 @@ func testnetify(ctx *Context, home string, testnetAppCreator types.AppCreator, d
 	appHash := res.LastBlockAppHash
 	appHeight := res.LastBlockHeight
 
-	// Delete the walDir and recreate the folder.
-	// These write ahead logs cause edge cases and serve no purpose for the testnet.
-	walDir := fmt.Sprintf("%s/cs.wal", config.DBDir())
-	err = os.RemoveAll(walDir)
-	if err != nil {
-		return nil, err
-	}
-	err = os.MkdirAll(walDir, 0o755)
-	if err != nil {
-		return nil, err
-	}
-
 	var block *cmttypes.Block
 	switch {
 	case appHeight == blockStore.Height():
 		block = blockStore.LoadBlock(blockStore.Height())
 		// If the state's last blockstore height does not match the app and blockstore height, we likely stopped with the halt height flag.
 		if state.LastBlockHeight != appHeight {
-			state.LastBlockHeight++
+			state.LastBlockHeight = appHeight
 			block.AppHash = appHash
 			state.AppHash = appHash
+		} else {
+			// Node was likely stopped via SIGTERM, delete the next block's seen commit
+			err := blockStoreDB.Delete([]byte(fmt.Sprintf("SC:%v", blockStore.Height()+1)))
+			if err != nil {
+				return nil, err
+			}
 		}
 	case blockStore.Height() > state.LastBlockHeight:
-		// This state usually occurs when we sig kill the node.
+		// This state usually occurs when we gracefully stop the node.
 		err = blockStore.DeleteLatestBlock()
 		if err != nil {
 			return nil, err

--- a/server/start.go
+++ b/server/start.go
@@ -820,21 +820,15 @@ func testnetify(ctx *Context, home string, testnetAppCreator types.AppCreator, d
 	block.LastCommit.Signatures[0].Signature = vote.Signature
 	block.LastCommit.Signatures = []cmttypes.CommitSig{block.LastCommit.Signatures[0]}
 
-	// Create a commit signed from our validator and save it
-	seenCommit := cmttypes.Commit{
-		Height:  state.LastBlockHeight,
-		Round:   vote.Round,
-		BlockID: state.LastBlockID,
-		Signatures: []cmttypes.CommitSig{
-			{
-				BlockIDFlag:      cmttypes.BlockIDFlagCommit,
-				Signature:        vote.Signature,
-				ValidatorAddress: validatorAddress,
-				Timestamp:        vote.Timestamp,
-			},
-		},
-	}
-	err = blockStore.SaveSeenCommit(state.LastBlockHeight, &seenCommit)
+	// Load the seenCommit of the lastBlockHeight and modify it to be signed from our validator
+	seenCommit := blockStore.LoadSeenCommit(state.LastBlockHeight)
+	seenCommit.BlockID = state.LastBlockID
+	seenCommit.Round = vote.Round
+	seenCommit.Signatures[0].Signature = vote.Signature
+	seenCommit.Signatures[0].ValidatorAddress = validatorAddress
+	seenCommit.Signatures[0].Timestamp = vote.Timestamp
+	seenCommit.Signatures = []cmttypes.CommitSig{seenCommit.Signatures[0]}
+	err = blockStore.SaveSeenCommit(state.LastBlockHeight, seenCommit)
 	if err != nil {
 		return nil, err
 	}

--- a/server/start.go
+++ b/server/start.go
@@ -21,6 +21,7 @@ import (
 	db "github.com/cometbft/cometbft-db"
 	"github.com/cometbft/cometbft/abci/server"
 	tcmd "github.com/cometbft/cometbft/cmd/cometbft/commands"
+	cmtcfg "github.com/cometbft/cometbft/config"
 	cmtjson "github.com/cometbft/cometbft/libs/json"
 	"github.com/cometbft/cometbft/node"
 	"github.com/cometbft/cometbft/p2p"
@@ -742,9 +743,7 @@ func testnetify(ctx *Context, home string, testnetAppCreator types.AppCreator, d
 	// Depending on how the node was stopped, the application height can differ from the blockStore height.
 	// This height difference changes how we go about modifying the state.
 	clientCreator := proxy.NewLocalClientCreator(testnetApp)
-	// This metrics provider is just for the proxy app, so we can utilize a nil input.
-	// If prometheus is enabled and we don't use a nil input, this panics.
-	metrics := node.DefaultMetricsProvider(nil)
+	metrics := node.DefaultMetricsProvider(cmtcfg.DefaultConfig().Instrumentation)
 	_, _, _, _, proxyMetrics := metrics(genDoc.ChainID) //nolint:dogsled
 	proxyApp := proxy.NewAppConns(clientCreator, proxyMetrics)
 	if err := proxyApp.Start(); err != nil {
@@ -761,16 +760,30 @@ func testnetify(ctx *Context, home string, testnetAppCreator types.AppCreator, d
 	appHash := res.LastBlockAppHash
 	appHeight := res.LastBlockHeight
 
+	// Delete the walDir and recreate the folder.
+	// These write ahead logs cause edge cases and serve no purpose for the testnet.
+	walDir := fmt.Sprintf("%s/cs.wal", config.DBDir())
+	err = os.RemoveAll(walDir)
+	if err != nil {
+		return nil, err
+	}
+	err = os.MkdirAll(walDir, 0o755)
+	if err != nil {
+		return nil, err
+	}
+
 	var block *cmttypes.Block
 	switch {
 	case appHeight == blockStore.Height():
-		// This state occurs when we stop the node with the halt height flag, and need to handle differently
-		state.LastBlockHeight++
 		block = blockStore.LoadBlock(blockStore.Height())
-		block.AppHash = appHash
-		state.AppHash = appHash
+		// If the state's last blockstore height does not match the app and blockstore height, we likely stopped with the halt height flag.
+		if state.LastBlockHeight != appHeight {
+			state.LastBlockHeight++
+			block.AppHash = appHash
+			state.AppHash = appHash
+		}
 	case blockStore.Height() > state.LastBlockHeight:
-		// This state occurs when we kill the node
+		// This state usually occurs when we sig kill the node.
 		err = blockStore.DeleteLatestBlock()
 		if err != nil {
 			return nil, err
@@ -813,15 +826,21 @@ func testnetify(ctx *Context, home string, testnetAppCreator types.AppCreator, d
 	block.LastCommit.Signatures[0].Signature = vote.Signature
 	block.LastCommit.Signatures = []cmttypes.CommitSig{block.LastCommit.Signatures[0]}
 
-	// Load the seenCommit of the lastBlockHeight and modify it to be signed from our validator
-	seenCommit := blockStore.LoadSeenCommit(state.LastBlockHeight)
-	seenCommit.BlockID = state.LastBlockID
-	seenCommit.Round = vote.Round
-	seenCommit.Signatures[0].Signature = vote.Signature
-	seenCommit.Signatures[0].ValidatorAddress = validatorAddress
-	seenCommit.Signatures[0].Timestamp = vote.Timestamp
-	seenCommit.Signatures = []cmttypes.CommitSig{seenCommit.Signatures[0]}
-	err = blockStore.SaveSeenCommit(state.LastBlockHeight, seenCommit)
+	// Create a commit signed from our validator and save it
+	seenCommit := cmttypes.Commit{
+		Height:  state.LastBlockHeight,
+		Round:   vote.Round,
+		BlockID: state.LastBlockID,
+		Signatures: []cmttypes.CommitSig{
+			{
+				BlockIDFlag:      cmttypes.BlockIDFlagCommit,
+				Signature:        vote.Signature,
+				ValidatorAddress: validatorAddress,
+				Timestamp:        vote.Timestamp,
+			},
+		},
+	}
+	err = blockStore.SaveSeenCommit(state.LastBlockHeight, &seenCommit)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: #XXXX

Killing a node, setting a halt height, and gracefully shutting down cause varying states of the block height across app/blockStore/state. This PR handles these states properly. 

Additionally, there was an edge case where if prometheus was enabled, it would panic due to setting it a second time in testnetify. We don't actually need the metrics provider to match what the user wants in testnetify since this is just used temporarily while setting up the application, so we use the default config of instrumentation to prevent this panic from happening.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
