### PR TITLE
Backport of https://github.com/cosmos/cosmos-sdk/pull/18959

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+* (slashing) [#18959](https://github.com/cosmos/cosmos-sdk/pull/18959) Slight speedup to Slashing Beginblock logic
+
 ## [v0.47.5](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.47.5) - 2023-09-01
 
 ### Features

--- a/x/slashing/abci.go
+++ b/x/slashing/abci.go
@@ -19,7 +19,8 @@ func BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock, k keeper.Keeper) 
 	// Iterate over all the validators which *should* have signed this block
 	// store whether or not they have actually signed it and slash/unbond any
 	// which have missed too many blocks in a row (downtime slashing)
+	params := k.GetParams(ctx)
 	for _, voteInfo := range req.LastCommitInfo.GetVotes() {
-		k.HandleValidatorSignature(ctx, voteInfo.Validator.Address, voteInfo.Validator.Power, voteInfo.SignedLastBlock)
+		k.HandleValidatorSignatureWithParams(ctx, params, voteInfo.Validator.Address, voteInfo.Validator.Power, voteInfo.SignedLastBlock)
 	}
 }

--- a/x/slashing/keeper/params.go
+++ b/x/slashing/keeper/params.go
@@ -15,11 +15,8 @@ func (k Keeper) SignedBlocksWindow(ctx sdk.Context) (res int64) {
 // MinSignedPerWindow - minimum blocks signed per window
 func (k Keeper) MinSignedPerWindow(ctx sdk.Context) int64 {
 	params := k.GetParams(ctx)
-	signedBlocksWindow := params.SignedBlocksWindow
 
-	// NOTE: RoundInt64 will never panic as minSignedPerWindow is
-	//       less than 1.
-	return params.MinSignedPerWindow.MulInt64(signedBlocksWindow).RoundInt64()
+	return params.MinSignedPerWindowInt()
 }
 
 // DowntimeJailDuration - Downtime unbond duration

--- a/x/slashing/types/params.go
+++ b/x/slashing/types/params.go
@@ -148,3 +148,13 @@ func validateSlashFractionDowntime(i interface{}) error {
 
 	return nil
 }
+
+// return min signed per window as an integer (vs the decimal in the param)
+func (p *Params) MinSignedPerWindowInt() int64 {
+	signedBlocksWindow := p.SignedBlocksWindow
+	minSignedPerWindow := p.MinSignedPerWindow
+
+	// NOTE: RoundInt64 will never panic as minSignedPerWindow is
+	//       less than 1.
+	return minSignedPerWindow.MulInt64(signedBlocksWindow).RoundInt64()
+}


### PR DESCRIPTION
Slight state compatible speedup to slashing.GetParams

This is a .3% state machine processing time speedup on IAVL v0, .5% on v1 no fast nodes.

Backporting this to more easily backport our more significant write reduction PR we made upstream.