### PR TITLE
fix: graceful prune failure log instead of panic

### DIFF
--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -460,7 +460,7 @@ func (rs *Store) Commit() types.CommitID {
 	rs.removalMap = make(map[types.StoreKey]bool)
 
 	if err := rs.handlePruning(version); err != nil {
-		panic(err)
+		rs.logger.Info("pruning failed at height", version, "err", err)
 	}
 
 	return types.CommitID{


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: #XXXX

Upstream already does this. When a snapshot is occurring, pruning will fail. We instead just log this failure instead of calling a panic.
