### PR TITLE
Trusted bech32 decoding

### DIFF
--- a/types/address.go
+++ b/types/address.go
@@ -209,6 +209,26 @@ func AccAddressFromBech32(address string) (addr AccAddress, err error) {
 	return AccAddress(bz), nil
 }
 
+func AccAddressFromTrustedBech32(address string) (addr AccAddress, err error) {
+	if len(strings.TrimSpace(address)) == 0 {
+		return AccAddress{}, errors.New("empty address string is not allowed")
+	}
+
+	bech32PrefixAccAddr := GetConfig().GetBech32AccountAddrPrefix()
+
+	bz, err := GetFromTrustedBech32(address, bech32PrefixAccAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	err = VerifyAddressFormat(bz)
+	if err != nil {
+		return nil, err
+	}
+
+	return AccAddress(bz), nil
+}
+
 // Returns boolean for whether two AccAddresses are Equal
 func (aa AccAddress) Equals(aa2 Address) bool {
 	if aa.Empty() && aa2.Empty() {
@@ -349,6 +369,26 @@ func ValAddressFromBech32(address string) (addr ValAddress, err error) {
 	bech32PrefixValAddr := GetConfig().GetBech32ValidatorAddrPrefix()
 
 	bz, err := GetFromBech32(address, bech32PrefixValAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	err = VerifyAddressFormat(bz)
+	if err != nil {
+		return nil, err
+	}
+
+	return ValAddress(bz), nil
+}
+
+func ValAddressFromTrustedBech32(address string) (addr ValAddress, err error) {
+	if len(strings.TrimSpace(address)) == 0 {
+		return ValAddress{}, errors.New("empty address string is not allowed")
+	}
+
+	bech32PrefixValAddr := GetConfig().GetBech32ValidatorAddrPrefix()
+
+	bz, err := GetFromTrustedBech32(address, bech32PrefixValAddr)
 	if err != nil {
 		return nil, err
 	}
@@ -676,6 +716,23 @@ func GetFromBech32(bech32str, prefix string) ([]byte, error) {
 	}
 
 	hrp, bz, err := bech32.DecodeAndConvert(bech32str)
+	if err != nil {
+		return nil, err
+	}
+
+	if hrp != prefix {
+		return nil, fmt.Errorf("invalid Bech32 prefix; expected %s, got %s", prefix, hrp)
+	}
+
+	return bz, nil
+}
+
+func GetFromTrustedBech32(bech32str, prefix string) ([]byte, error) {
+	if len(bech32str) == 0 {
+		return nil, errBech32EmptyAddress
+	}
+
+	hrp, bz, err := bech32.TrustedDataDecodeAndConvert(bech32str)
 	if err != nil {
 		return nil, err
 	}

--- a/types/bech32/bech32.go
+++ b/types/bech32/bech32.go
@@ -30,3 +30,20 @@ func DecodeAndConvert(bech string) (string, []byte, error) {
 
 	return hrp, converted, nil
 }
+
+// TrustedDataDecodeAndConvert decodes a bech32 encoded string and converts to base64 encoded bytes.
+// It assumes that the bech32 string is trusted data and does not check the checksum.
+func TrustedDataDecodeAndConvert(bech string) (string, []byte, error) {
+	// This function does not panic under any circumstance.
+	hrp, data, _, err := bech32.DecodeUnsafe(bech)
+	if err != nil {
+		return "", nil, fmt.Errorf("decoding bech32 failed: %w", err)
+	}
+
+	converted, err := bech32.ConvertBits(data, 5, 8, false)
+	if err != nil {
+		return "", nil, fmt.Errorf("decoding bech32 failed: %w", err)
+	}
+
+	return hrp, converted, nil
+}

--- a/types/bech32/bech32_test.go
+++ b/types/bech32/bech32_test.go
@@ -22,6 +22,11 @@ func TestEncodeAndDecode(t *testing.T) {
 
 	require.Equal(t, hrp, ss, "Invalid hrp")
 	require.True(t, bytes.Equal(data, sum[:]), "Invalid decode")
+
+	hrp, data, err = bech32.TrustedDataDecodeAndConvert(bech)
+	require.NoError(t, err)
+	require.Equal(t, hrp, ss, "Invalid hrp")
+	require.True(t, bytes.Equal(data, sum[:]), "Invalid decode")
 }
 
 func FuzzDecodeAndConvert(f *testing.F) {
@@ -31,8 +36,10 @@ func FuzzDecodeAndConvert(f *testing.F) {
 
 	f.Add("shasum149yfqne0parehrupja55kvqcfvxja5wpe54pas8mshffngvj53rs93fk75")
 	f.Add("bech321er8m900ayvv9rg5r6ush4nzvqhj4p9tqnxqkxaaxrs4ueuvhurcs4x3j4j")
+	f.Add("bech311121er8m900ayvv9rg5r6ush4nzvqhj4p9tqnxqkxaaxrs4ueuvhurcs4x3j4j")
 
 	f.Fuzz(func(t *testing.T, str string) {
 		_, _, _ = bech32.DecodeAndConvert(str)
+		_, _, _ = bech32.TrustedDataDecodeAndConvert(str)
 	})
 }


### PR DESCRIPTION
We should use this to speedup operations with decoding addresses in Osmosis. 

I'd expect a .3% sync speedup from just using this in the CL module. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new functions for trusted Bech32 address conversion, enhancing address validation and error handling.
	- Added a function for decoding Bech32 encoded strings to base64 encoded bytes without checksum verification for safer execution.
- **Tests**
	- Implemented test cases for the new Bech32 decoding function, including standard and fuzzing tests to ensure reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->