### PR TITLE
fix: less time intensive slashing migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (slashing) [#543](https://github.com/osmosis-labs/cosmos-sdk/pull/543) Make slashing not write sign info every block
 * (authz) [#513](https://github.com/osmosis-labs/cosmos-sdk/pull/513) Limit expired authz grant pruning to 200 per block
 * (gov) [#514](https://github.com/osmosis-labs/cosmos-sdk/pull/514) Let gov hooks return an error
+* (slashing) [#580](https://github.com/osmosis-labs/cosmos-sdk/pull/580) Less time intensive slashing migration
 
 ## [State Compatible]
 

--- a/x/slashing/abci.go
+++ b/x/slashing/abci.go
@@ -25,5 +25,5 @@ func BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock, k keeper.Keeper) 
 	}
 
 	// If there are still old entries for the MissedBlockBitArray, delete them up until we hit the per block limit
-	k.DeleteDeprecatedValidatorMissedBlockBitArray(ctx, 1000)
+	k.DeleteDeprecatedValidatorMissedBlockBitArray(ctx, 1000000)
 }

--- a/x/slashing/abci.go
+++ b/x/slashing/abci.go
@@ -23,4 +23,7 @@ func BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock, k keeper.Keeper) 
 	for _, voteInfo := range req.LastCommitInfo.GetVotes() {
 		k.HandleValidatorSignatureWithParams(ctx, params, voteInfo.Validator.Address, voteInfo.Validator.Power, voteInfo.SignedLastBlock)
 	}
+
+	// If there are still old entries for the MissedBlockBitArray, delete them up until we hit the per block limit
+	k.DeleteDeprecatedValidatorMissedBlockBitArray(ctx, 1000)
 }

--- a/x/slashing/abci.go
+++ b/x/slashing/abci.go
@@ -11,6 +11,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/slashing/types"
 )
 
+var deprecatedBitArrayPruneLimitPerBlock = 2000
+
 // BeginBlocker check for infraction evidence or downtime of validators
 // on every begin block
 func BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock, k keeper.Keeper) {
@@ -24,6 +26,6 @@ func BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock, k keeper.Keeper) 
 		k.HandleValidatorSignatureWithParams(ctx, params, voteInfo.Validator.Address, voteInfo.Validator.Power, voteInfo.SignedLastBlock)
 	}
 
-	// If there are still old entries for the MissedBlockBitArray, delete them up until we hit the per block limit
-	k.DeleteDeprecatedValidatorMissedBlockBitArray(ctx, 1000000)
+	// If there are still entries for the deprecated MissedBlockBitArray, delete them up until we hit the per block limit
+	k.DeleteDeprecatedValidatorMissedBlockBitArray(ctx, deprecatedBitArrayPruneLimitPerBlock)
 }

--- a/x/slashing/keeper/keeper.go
+++ b/x/slashing/keeper/keeper.go
@@ -149,9 +149,9 @@ func (k Keeper) DeleteDeprecatedValidatorMissedBlockBitArray(ctx sdk.Context, it
 		}
 	}
 
-	fmt.Printf("Deleted %d deprecated missed block bit arrays\n", iterationCounter)
+	ctx.Logger().Info("Deleted deprecated missed block bit arrays", "count", iterationCounter)
 
-	// if we have deleted all the deprecated missed block bit arrays, we can delete the pruning key
+	// if we have deleted all the deprecated missed block bit arrays, we can delete the pruning key (setting to nil)
 	if iterationCounter == 0 {
 		store.Delete(types.IsPruningKey)
 	}

--- a/x/slashing/keeper/keeper.go
+++ b/x/slashing/keeper/keeper.go
@@ -123,6 +123,7 @@ func (k Keeper) DeleteDeprecatedValidatorMissedBlockBitArray(ctx sdk.Context, it
 		return
 	}
 
+	// Iterate over all the validator signing infos and delete the deprecated missed block bit arrays
 	valSignInfoIter := sdk.KVStorePrefixIterator(store, types.ValidatorSigningInfoKeyPrefix)
 	defer valSignInfoIter.Close()
 
@@ -130,7 +131,7 @@ func (k Keeper) DeleteDeprecatedValidatorMissedBlockBitArray(ctx sdk.Context, it
 	for ; valSignInfoIter.Valid(); valSignInfoIter.Next() {
 		address := types.ValidatorSigningInfoAddress(valSignInfoIter.Key())
 
-		// created anonymous function to scope defer statement
+		// Creat anonymous function to scope defer statement
 		func() {
 			iter := storetypes.KVStorePrefixIterator(store, v4.DeprecatedValidatorMissedBlockBitArrayPrefixKey(address))
 			defer iter.Close()
@@ -151,7 +152,7 @@ func (k Keeper) DeleteDeprecatedValidatorMissedBlockBitArray(ctx sdk.Context, it
 
 	ctx.Logger().Info("Deleted deprecated missed block bit arrays", "count", iterationCounter)
 
-	// if we have deleted all the deprecated missed block bit arrays, we can delete the pruning key (setting to nil)
+	// If we have deleted all the deprecated missed block bit arrays, we can delete the pruning key (set to nil)
 	if iterationCounter == 0 {
 		store.Delete(types.IsPruningKey)
 	}

--- a/x/slashing/keeper/keeper.go
+++ b/x/slashing/keeper/keeper.go
@@ -151,8 +151,8 @@ func (k Keeper) DeleteDeprecatedValidatorMissedBlockBitArray(ctx sdk.Context, it
 
 	fmt.Printf("Deleted %d deprecated missed block bit arrays\n", iterationCounter)
 
-	// if we have deleted all the deprecated missed block bit arrays, we can set the pruning key to nil
+	// if we have deleted all the deprecated missed block bit arrays, we can delete the pruning key
 	if iterationCounter == 0 {
-		store.Set(types.IsPruningKey, nil)
+		store.Delete(types.IsPruningKey)
 	}
 }

--- a/x/slashing/keeper/keeper.go
+++ b/x/slashing/keeper/keeper.go
@@ -143,6 +143,10 @@ func (k Keeper) DeleteDeprecatedValidatorMissedBlockBitArray(ctx sdk.Context, it
 				}
 			}
 		}()
+
+		if iterationCounter >= iterationLimit {
+			break
+		}
 	}
 
 	fmt.Printf("Deleted %d deprecated missed block bit arrays\n", iterationCounter)

--- a/x/slashing/migrations/v4/keys.go
+++ b/x/slashing/migrations/v4/keys.go
@@ -11,8 +11,13 @@ import (
 const MissedBlockBitmapChunkSize = 1024 // 2^10 bits
 
 var (
-	ValidatorSigningInfoKeyPrefix         = []byte{0x01}
-	validatorMissedBlockBitArrayKeyPrefix = []byte{0x02}
+	ValidatorSigningInfoKeyPrefix                   = []byte{0x01}
+	deprecatedValidatorMissedBlockBitArrayKeyPrefix = []byte{0x02}
+
+	// NOTE: sdk v0.50 uses the same key prefix for both deprecated and new missed block bitmaps.
+	// We needed to use a new key, because we are skipping deletion of all old keys at upgrade time
+	// due to how long this would bring the chain down. We use 0x10 here to prevent overlap with any future keys.
+	validatorMissedBlockBitMapKeyPrefix = []byte{0x10}
 )
 
 func ValidatorSigningInfoKey(v sdk.ConsAddress) []byte {
@@ -27,18 +32,18 @@ func ValidatorSigningInfoAddress(key []byte) (v sdk.ConsAddress) {
 	return sdk.ConsAddress(addr)
 }
 
-func validatorMissedBlockBitArrayPrefixKey(v sdk.ConsAddress) []byte {
-	return append(validatorMissedBlockBitArrayKeyPrefix, address.MustLengthPrefix(v.Bytes())...)
+func DeprecatedValidatorMissedBlockBitArrayPrefixKey(v sdk.ConsAddress) []byte {
+	return append(deprecatedValidatorMissedBlockBitArrayKeyPrefix, address.MustLengthPrefix(v.Bytes())...)
 }
 
-func ValidatorMissedBlockBitArrayKey(v sdk.ConsAddress, i int64) []byte {
+func DeprecatedValidatorMissedBlockBitArrayKey(v sdk.ConsAddress, i int64) []byte {
 	b := make([]byte, 8)
 	binary.LittleEndian.PutUint64(b, uint64(i))
-	return append(validatorMissedBlockBitArrayPrefixKey(v), b...)
+	return append(DeprecatedValidatorMissedBlockBitArrayPrefixKey(v), b...)
 }
 
 func validatorMissedBlockBitmapPrefixKey(v sdk.ConsAddress) []byte {
-	return append(validatorMissedBlockBitArrayKeyPrefix, address.MustLengthPrefix(v.Bytes())...)
+	return append(validatorMissedBlockBitMapKeyPrefix, address.MustLengthPrefix(v.Bytes())...)
 }
 
 func ValidatorMissedBlockBitmapKey(v sdk.ConsAddress, chunkIndex int64) []byte {

--- a/x/slashing/migrations/v4/migrate.go
+++ b/x/slashing/migrations/v4/migrate.go
@@ -39,7 +39,7 @@ func Migrate(ctx sdk.Context, cdc codec.BinaryCodec, store storetypes.KVStore, p
 			return err
 		}
 
-		//deleteValidatorMissedBlockBitArray(ctx, store, addr)
+		deleteValidatorMissedBlockBitArray(ctx, store, addr)
 
 		for _, b := range mb.MissedBlocks {
 			// Note: It is not necessary to store entries with missed=false, i.e. where

--- a/x/slashing/migrations/v4/migrate.go
+++ b/x/slashing/migrations/v4/migrate.go
@@ -119,14 +119,15 @@ func GetValidatorMissedBlocks(
 	return missedBlocks
 }
 
-func deleteDeprecatedValidatorMissedBlockBitArray(ctx sdk.Context, store storetypes.KVStore, addr sdk.ConsAddress) {
-	iter := storetypes.KVStorePrefixIterator(store, DeprecatedValidatorMissedBlockBitArrayPrefixKey(addr))
-	defer iter.Close()
+// No longer use this
+// func deleteDeprecatedValidatorMissedBlockBitArray(ctx sdk.Context, store storetypes.KVStore, addr sdk.ConsAddress) {
+// 	iter := storetypes.KVStorePrefixIterator(store, DeprecatedValidatorMissedBlockBitArrayPrefixKey(addr))
+// 	defer iter.Close()
 
-	for ; iter.Valid(); iter.Next() {
-		store.Delete(iter.Key())
-	}
-}
+// 	for ; iter.Valid(); iter.Next() {
+// 		store.Delete(iter.Key())
+// 	}
+// }
 
 func setMissedBlockBitmapValue(ctx sdk.Context, store storetypes.KVStore, addr sdk.ConsAddress, index int64, missed bool) error {
 	// get the chunk or "word" in the logical bitmap

--- a/x/slashing/migrations/v4/migrate.go
+++ b/x/slashing/migrations/v4/migrate.go
@@ -21,11 +21,11 @@ func Migrate(ctx sdk.Context, cdc codec.BinaryCodec, store storetypes.KVStore, p
 	var missedBlocks []types.ValidatorMissedBlocks
 	iterateValidatorSigningInfos(ctx, cdc, store, func(addr sdk.ConsAddress, info types.ValidatorSigningInfo) (stop bool) {
 		bechAddr := addr.String()
-		localMissedBlocks := GetValidatorMissedBlocks(ctx, cdc, store, addr, params)
+		//localMissedBlocks := GetValidatorMissedBlocks(ctx, cdc, store, addr, params)
 
 		missedBlocks = append(missedBlocks, types.ValidatorMissedBlocks{
 			Address:      bechAddr,
-			MissedBlocks: localMissedBlocks,
+			MissedBlocks: []types.MissedBlock{},
 		})
 
 		return false

--- a/x/slashing/migrations/v4/migrate.go
+++ b/x/slashing/migrations/v4/migrate.go
@@ -1,6 +1,8 @@
 package v4
 
 import (
+	"fmt"
+
 	"github.com/bits-and-blooms/bitset"
 	gogotypes "github.com/cosmos/gogoproto/types"
 
@@ -117,10 +119,14 @@ func GetValidatorMissedBlocks(
 func deleteValidatorMissedBlockBitArray(ctx sdk.Context, store storetypes.KVStore, addr sdk.ConsAddress) {
 	iter := storetypes.KVStorePrefixIterator(store, validatorMissedBlockBitArrayPrefixKey(addr))
 	defer iter.Close()
+	i := 0
 
 	for ; iter.Valid(); iter.Next() {
+		i++
 		store.Delete(iter.Key())
 	}
+
+	fmt.Printf("deleted %d missed block bit array entries for validator %s\n", i, addr)
 }
 
 func setMissedBlockBitmapValue(ctx sdk.Context, store storetypes.KVStore, addr sdk.ConsAddress, index int64, missed bool) error {

--- a/x/slashing/migrations/v4/migrate.go
+++ b/x/slashing/migrations/v4/migrate.go
@@ -21,7 +21,9 @@ func Migrate(ctx sdk.Context, cdc codec.BinaryCodec, store storetypes.KVStore, p
 	var missedBlocks []types.ValidatorMissedBlocks
 	iterateValidatorSigningInfos(ctx, cdc, store, func(addr sdk.ConsAddress, info types.ValidatorSigningInfo) (stop bool) {
 		bechAddr := addr.String()
-		//localMissedBlocks := GetValidatorMissedBlocks(ctx, cdc, store, addr, params)
+
+		// We opt to reset all validators missed blocks to improve upgrade performance
+		// localMissedBlocks := GetValidatorMissedBlocks(ctx, cdc, store, addr, params)
 
 		missedBlocks = append(missedBlocks, types.ValidatorMissedBlocks{
 			Address:      bechAddr,
@@ -120,10 +122,8 @@ func GetValidatorMissedBlocks(
 func deleteDeprecatedValidatorMissedBlockBitArray(ctx sdk.Context, store storetypes.KVStore, addr sdk.ConsAddress) {
 	iter := storetypes.KVStorePrefixIterator(store, DeprecatedValidatorMissedBlockBitArrayPrefixKey(addr))
 	defer iter.Close()
-	i := 0
 
 	for ; iter.Valid(); iter.Next() {
-		i++
 		store.Delete(iter.Key())
 	}
 }

--- a/x/slashing/migrations/v4/migrate.go
+++ b/x/slashing/migrations/v4/migrate.go
@@ -39,7 +39,7 @@ func Migrate(ctx sdk.Context, cdc codec.BinaryCodec, store storetypes.KVStore, p
 			return err
 		}
 
-		deleteValidatorMissedBlockBitArray(ctx, store, addr)
+		//deleteValidatorMissedBlockBitArray(ctx, store, addr)
 
 		for _, b := range mb.MissedBlocks {
 			// Note: It is not necessary to store entries with missed=false, i.e. where

--- a/x/slashing/migrations/v4/migrate_test.go
+++ b/x/slashing/migrations/v4/migrate_test.go
@@ -3,7 +3,6 @@ package v4_test
 import (
 	"testing"
 
-	"github.com/bits-and-blooms/bitset"
 	gogotypes "github.com/cosmos/gogoproto/types"
 	"github.com/stretchr/testify/require"
 
@@ -44,15 +43,18 @@ func TestMigrate(t *testing.T) {
 	for i := int64(0); i < params.SignedBlocksWindow; i++ {
 		chunkIndex := i / v4.MissedBlockBitmapChunkSize
 		chunk := store.Get(v4.ValidatorMissedBlockBitmapKey(consAddr, chunkIndex))
-		require.NotNil(t, chunk)
 
-		bs := bitset.New(uint(v4.MissedBlockBitmapChunkSize))
-		require.NoError(t, bs.UnmarshalBinary(chunk))
+		// We reset all validators missed blocks to improve upgrade performance,
+		// so we expect all chunks to be empty
+		require.Nil(t, chunk)
 
-		// ensure all even blocks are missed
-		bitIndex := uint(i % v4.MissedBlockBitmapChunkSize)
-		require.Equal(t, i%2 == 0, bs.Test(bitIndex))
-		require.Equal(t, i%2 == 1, !bs.Test(bitIndex))
+		// bs := bitset.New(uint(v4.MissedBlockBitmapChunkSize))
+		// require.NoError(t, bs.UnmarshalBinary(chunk))
+
+		// // ensure all even blocks are missed
+		// bitIndex := uint(i % v4.MissedBlockBitmapChunkSize)
+		// require.Equal(t, i%2 == 0, bs.Test(bitIndex))
+		// require.Equal(t, i%2 == 1, !bs.Test(bitIndex))
 	}
 
 	// ensure there's only one chunk for a window of size 100

--- a/x/slashing/migrations/v4/migrate_test.go
+++ b/x/slashing/migrations/v4/migrate_test.go
@@ -35,7 +35,7 @@ func TestMigrate(t *testing.T) {
 		// all even blocks are missed
 		missed := &gogotypes.BoolValue{Value: i%2 == 0}
 		bz := cdc.MustMarshal(missed)
-		store.Set(v4.ValidatorMissedBlockBitArrayKey(consAddr, i), bz)
+		store.Set(v4.DeprecatedValidatorMissedBlockBitArrayKey(consAddr, i), bz)
 	}
 
 	err := v4.Migrate(ctx, cdc, store, params)

--- a/x/slashing/types/keys.go
+++ b/x/slashing/types/keys.go
@@ -48,10 +48,11 @@ const (
 // - 0x03<accAddrLen (1 Byte)><accAddr_Bytes>: cryptotypes.PubKey
 
 var (
-	ParamsKey                           = []byte{0x00} // Prefix for params key
-	ValidatorSigningInfoKeyPrefix       = []byte{0x01} // Prefix for signing info
-	ValidatorMissedBlockBitmapKeyPrefix = []byte{0x02} // Prefix for missed block bitmap
-	AddrPubkeyRelationKeyPrefix         = []byte{0x03} // Prefix for address-pubkey relation
+	ParamsKey                     = []byte{0x00} // Prefix for params key
+	ValidatorSigningInfoKeyPrefix = []byte{0x01} // Prefix for signing info
+	AddrPubkeyRelationKeyPrefix   = []byte{0x03} // Prefix for address-pubkey relation
+
+	ValidatorMissedBlockBitmapKeyPrefix = []byte{0x10} // Prefix for missed block bitmap
 
 	IsPruningKey  = []byte{0x09}
 	TrueByteValue = []byte{0x01}

--- a/x/slashing/types/keys.go
+++ b/x/slashing/types/keys.go
@@ -52,6 +52,9 @@ var (
 	ValidatorSigningInfoKeyPrefix       = []byte{0x01} // Prefix for signing info
 	ValidatorMissedBlockBitmapKeyPrefix = []byte{0x02} // Prefix for missed block bitmap
 	AddrPubkeyRelationKeyPrefix         = []byte{0x03} // Prefix for address-pubkey relation
+
+	IsPruningKey  = []byte{0x09}
+	TrueByteValue = []byte{0x01}
 )
 
 // ValidatorSigningInfoKey - stored by *Consensus* address (not operator address)


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

Updates slashing migration logic to:
1. Reset all validators slashing window to 0 instead of porting over their current state
2. Delete 2000 records per block until completion instead of all at once

### Testing

I did a broad test with the in-place-testnet and all seemed well. When we do a more thorough upgrade test with multiple validators, we should bring a validator down and ensure the counter incs as expected.

Just b/c it took me a little to figure this out let me write it here:

You get the validator address like:
`osmosisd tendermint show-validator`

And then get signing info like:
`osmosisd q slashing signing-info '{"@type":"/cosmos.crypto.ed25519.PubKey","key":"kY2Q8mLJkMgK9aFfZlvfllUiiP0D+h7HC+3hH87Qosk="}'`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced performance by efficiently deleting deprecated data related to validator missed blocks.
- **Refactor**
	- Updated key prefixes for validator information and missed block bitmaps to support improved data handling methods.
- **Chores**
	- Implemented a global limit for deleting deprecated bit array entries per block to optimize performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->