### PR TITLE
chore: add back removal regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## v24
 
-## [v0.47.5-v24-osmo-2](https://github.com/osmosis-labs/cosmos-sdk/releases/tag/v0.47.5-v24-osmo-2)
+## [v0.47.5-v24-osmo-3](https://github.com/osmosis-labs/cosmos-sdk/releases/tag/v0.47.5-v24-osmo-3)
 
 * (store) [#525](https://github.com/osmosis-labs/cosmos-sdk/pull/525) CacheKV speedups
 * (slashing) [#548](https://github.com/osmosis-labs/cosmos-sdk/pull/548) Implement v0.50 slashing bitmap logic

--- a/tests/e2e/authz/tx.go
+++ b/tests/e2e/authz/tx.go
@@ -339,7 +339,7 @@ func (s *E2ETestSuite) TestCLITxGrantAuthorization() {
 			},
 			0,
 			true,
-			"invalid decimal coin expression",
+			"invalid character in denomination",
 		},
 		{
 			"valid tx delegate authorization allowed validators",

--- a/tests/integration/bank/keeper/deterministic_test.go
+++ b/tests/integration/bank/keeper/deterministic_test.go
@@ -36,7 +36,7 @@ type DeterministicTestSuite struct {
 }
 
 var (
-	denomRegex   = sdk.DefaultCoinDenomRegex()
+	denomRegex   = `[a-zA-Z][a-zA-Z0-9/:._-]{2,127}`
 	addr1        = sdk.MustAccAddressFromBech32("cosmos139f7kncmglres2nf3h4hc4tade85ekfr8sulz5")
 	coin1        = sdk.NewCoin("denom", sdk.NewInt(10))
 	metadataAtom = banktypes.Metadata{

--- a/tests/integration/staking/keeper/determinstic_test.go
+++ b/tests/integration/staking/keeper/determinstic_test.go
@@ -687,9 +687,10 @@ func (suite *DeterministicTestSuite) TestGRPCRedelegations() {
 }
 
 func (suite *DeterministicTestSuite) TestGRPCParams() {
+	coinDenomRegex := `[a-zA-Z][a-zA-Z0-9/:._-]{2,127}`
 	rapid.Check(suite.T(), func(t *rapid.T) {
 		params := stakingtypes.Params{
-			BondDenom:         rapid.StringMatching(sdk.DefaultCoinDenomRegex()).Draw(t, "bond-denom"),
+			BondDenom:         rapid.StringMatching(coinDenomRegex).Draw(t, "bond-denom"),
 			UnbondingTime:     durationGenerator().Draw(t, "duration"),
 			MaxValidators:     rapid.Uint32Min(1).Draw(t, "max-validators"),
 			MaxEntries:        rapid.Uint32Min(1).Draw(t, "max-entries"),

--- a/types/coin_test.go
+++ b/types/coin_test.go
@@ -112,6 +112,8 @@ func (s *coinTestSuite) TestCoinIsValid() {
 
 func (s *coinTestSuite) TestCustomValidation() {
 	newDnmRegex := `[\x{1F600}-\x{1F6FF}]`
+	reDnmString := `[a-zA-Z][a-zA-Z0-9/:._-]{2,127}`
+
 	sdk.SetCoinDenomRegex(func() string {
 		return newDnmRegex
 	})
@@ -130,7 +132,7 @@ func (s *coinTestSuite) TestCustomValidation() {
 	for i, tc := range cases {
 		s.Require().Equal(tc.expectPass, tc.coin.IsValid(), "unexpected result for IsValid, tc #%d", i)
 	}
-	sdk.SetCoinDenomRegex(sdk.DefaultCoinDenomRegex)
+	sdk.SetCoinDenomRegex(func() string { return reDnmString })
 }
 
 func (s *coinTestSuite) TestCoinsDenoms() {
@@ -994,6 +996,33 @@ func (s *coinTestSuite) TestParseCoins() {
 			s.Require().Error(err, "%s: %#v. tc #%d", tc.input, res, tcIndex)
 		} else if s.Assert().Nil(err, "%s: %+v", tc.input, err) {
 			s.Require().Equal(tc.expected, res, "coin parsing was incorrect, tc #%d", tcIndex)
+		}
+	}
+}
+
+func (s *coinTestSuite) TestValidateDenom() {
+	cases := []struct {
+		input string
+		valid bool
+	}{
+		{"", false},
+		{"stake", true},
+		{"stake,", false},
+		{"me coin", false},
+		{"me coin much", false},
+		{"not a coin", false},
+		{"foo:bar", true}, // special characters '/' | ':' | '.' | '_' | '-' are allowed
+		{"atom10", true},  // number in denom is allowed
+		{"transfer/channelToA/uatom", true},
+		{"ibc/7F1D3FCF4AE79E1554D670D1AD949A9BA4E4A3C76C63093E17E446A46061A7A2", true},
+	}
+
+	for _, tc := range cases {
+		err := sdk.ValidateDenom(tc.input)
+		if !tc.valid {
+			s.Require().Error(err)
+		} else {
+			s.Require().NoError(err)
 		}
 	}
 }

--- a/types/dec_coin.go
+++ b/types/dec_coin.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"unicode"
 
 	"github.com/pkg/errors"
 )
@@ -621,14 +622,23 @@ func (coins DecCoins) Sort() DecCoins {
 // ParseDecCoin parses a decimal coin from a string, returning an error if
 // invalid. An empty string is considered invalid.
 func ParseDecCoin(coinStr string) (coin DecCoin, err error) {
-	coinStr = strings.TrimSpace(coinStr)
+	var amountStr, denomStr string
+	// if custom parsing has not been set, use default coin regex
+	if reDecCoin == nil { //nolint:gocritic
+		amountStr, denomStr, err = ParseDecAmount(coinStr)
+		if err != nil {
+			return DecCoin{}, err
+		}
+	} else {
+		coinStr = strings.TrimSpace(coinStr)
 
-	matches := reDecCoin.FindStringSubmatch(coinStr)
-	if matches == nil {
-		return DecCoin{}, fmt.Errorf("invalid decimal coin expression: %s", coinStr)
+		matches := reDecCoin.FindStringSubmatch(coinStr)
+		if matches == nil {
+			return DecCoin{}, fmt.Errorf("invalid decimal coin expression: %s", coinStr)
+		}
+
+		amountStr, denomStr = matches[1], matches[2]
 	}
-
-	amountStr, denomStr := matches[1], matches[2]
 
 	amount, err := NewDecFromStr(amountStr)
 	if err != nil {
@@ -640,6 +650,50 @@ func ParseDecCoin(coinStr string) (coin DecCoin, err error) {
 	}
 
 	return NewDecCoinFromDec(denomStr, amount), nil
+}
+
+// ParseDecAmount parses the given string into amount, denomination.
+func ParseDecAmount(coinStr string) (string, string, error) {
+	var amountRune, denomRune []rune
+
+	// Indicates the start of denom parsing
+	seenLetter := false
+	// Indicates we're currently parsing the amount
+	parsingAmount := true
+
+	for _, r := range strings.TrimSpace(coinStr) {
+		if parsingAmount { //nolint:gocritic
+			if unicode.IsDigit(r) || r == '.' { //nolint:gocritic
+				amountRune = append(amountRune, r)
+			} else if unicode.IsSpace(r) { // if space is seen, indicates that we have finished parsing amount
+				parsingAmount = false
+			} else if unicode.IsLetter(r) { // if letter is seen, indicates that it is the start of denom
+				parsingAmount = false
+				seenLetter = true
+				denomRune = append(denomRune, r)
+			} else { // Invalid character encountered in amount part
+				return "", "", fmt.Errorf("invalid character in coin string: %s", string(r))
+			}
+		} else if !seenLetter { // This logic flow is for skipping spaces between amount and denomination
+			if unicode.IsLetter(r) {
+				seenLetter = true
+				denomRune = append(denomRune, r)
+			} else if !unicode.IsSpace(r) {
+				// Invalid character before denomination starts
+				return "", "", fmt.Errorf("invalid start of denomination: %s", string(r))
+			}
+		} else {
+			// Parsing the denomination
+			if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '/' || r == ':' || r == '.' || r == '_' || r == '-' {
+				denomRune = append(denomRune, r)
+			} else {
+				// Invalid character encountered in denomination part
+				return "", "", fmt.Errorf("invalid character in denomination: %s", string(r))
+			}
+		}
+	}
+
+	return string(amountRune), string(denomRune), nil
 }
 
 // ParseDecCoins will parse out a list of decimal coins separated by commas. If the parsing is successuful,

--- a/x/authz/client/cli/tx_test.go
+++ b/x/authz/client/cli/tx_test.go
@@ -326,7 +326,7 @@ func (s *CLITestSuite) TestCLITxGrantAuthorization() {
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin("stake", sdk.NewInt(10))).String()),
 			},
 			true,
-			"invalid decimal coin expression",
+			"nvalid character in denomination: ",
 		},
 		{
 			"Valid tx send authorization",

--- a/x/gov/client/cli/util_test.go
+++ b/x/gov/client/cli/util_test.go
@@ -347,7 +347,7 @@ func TestReadGovPropFlags(t *testing.T) {
 			name:     "only deposit invalid coins",
 			fromAddr: nil,
 			args:     []string{argDeposit, "not really coins"},
-			expErr:   []string{"invalid deposit", "invalid decimal coin expression", "not really coins"},
+			expErr:   []string{"invalid deposit", "invalid character in denomination"},
 		},
 		{
 			name:     "only deposit two coins",
@@ -377,19 +377,19 @@ func TestReadGovPropFlags(t *testing.T) {
 			name:     "only deposit coin 1 of 3 bad",
 			fromAddr: nil,
 			args:     []string{argDeposit, "1bad^coin,2bcoin,3ccoin"},
-			expErr:   []string{"invalid deposit", "invalid decimal coin expression", "1bad^coin"},
+			expErr:   []string{"invalid deposit", "invalid character in denomination"},
 		},
 		{
 			name:     "only deposit coin 2 of 3 bad",
 			fromAddr: nil,
 			args:     []string{argDeposit, "1acoin,2bad^coin,3ccoin"},
-			expErr:   []string{"invalid deposit", "invalid decimal coin expression", "2bad^coin"},
+			expErr:   []string{"invalid deposit", "invalid character in denomination"},
 		},
 		{
 			name:     "only deposit coin 3 of 3 bad",
 			fromAddr: nil,
 			args:     []string{argDeposit, "1acoin,2bcoin,3bad^coin"},
-			expErr:   []string{"invalid deposit", "invalid decimal coin expression", "3bad^coin"},
+			expErr:   []string{"invalid deposit", "invalid character in denomination"},
 		},
 		// As far as I can tell, there's no way to make flagSet.GetString return an error for a defined string flag.
 		// So I don't have a test for the "could not read deposit" error case.


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: #XXXX

Matt tested and determined this PR is non problematic. Adding it back.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Implemented caching speedups in `CacheKV`.
	- Introduced v0.50 slashing bitmap logic in the latest release.
- **Bug Fixes**
	- Updated error messages for invalid coin denominations across various tests and functions.
- **Refactor**
	- Changed the regular expression for coin denominations to support a broader range of characters.
	- Enhanced validation logic for coin denominations, including custom parsing logic for decimal coins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->