### PR TITLE
Remove IAVL per-get/delete timing info

### DIFF
--- a/store/iavl/store.go
+++ b/store/iavl/store.go
@@ -204,7 +204,6 @@ func (st *Store) Set(key, value []byte) {
 
 // Implements types.KVStore.
 func (st *Store) Get(key []byte) []byte {
-	defer telemetry.MeasureSince(time.Now(), "store", "iavl", "get")
 	value, err := st.tree.Get(key)
 	if err != nil {
 		panic(err)
@@ -214,7 +213,6 @@ func (st *Store) Get(key []byte) []byte {
 
 // Implements types.KVStore.
 func (st *Store) Has(key []byte) (exists bool) {
-	defer telemetry.MeasureSince(time.Now(), "store", "iavl", "has")
 	has, err := st.tree.Has(key)
 	if err != nil {
 		panic(err)
@@ -224,7 +222,6 @@ func (st *Store) Has(key []byte) (exists bool) {
 
 // Implements types.KVStore.
 func (st *Store) Delete(key []byte) {
-	defer telemetry.MeasureSince(time.Now(), "store", "iavl", "delete")
 	st.tree.Remove(key)
 }
 


### PR DESCRIPTION
Remove timing info from every IAVL get/delete call.

Varies between .5 to 1% speedups to blocksync, and I have never once used this telemetry info.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the timing of telemetry measurements in the `Get`, `Has`, and `Delete` operations to enhance performance tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->