### PR TITLE
[wip] Try removing config singleton

### DIFF
--- a/client/debug/main.go
+++ b/client/debug/main.go
@@ -330,9 +330,9 @@ func PrefixesCmd() *cobra.Command {
 		Long:    "List prefixes used in Bech32 addresses.",
 		Example: fmt.Sprintf("$ %s debug prefixes", version.AppName),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cmd.Printf("Bech32 Acc: %s\n", sdk.GetConfig().GetBech32AccountAddrPrefix())
-			cmd.Printf("Bech32 Val: %s\n", sdk.GetConfig().GetBech32ValidatorAddrPrefix())
-			cmd.Printf("Bech32 Con: %s\n", sdk.GetConfig().GetBech32ConsensusAddrPrefix())
+			cmd.Printf("Bech32 Acc: %s\n", sdk.NewConfig().GetBech32AccountAddrPrefix())
+			cmd.Printf("Bech32 Val: %s\n", sdk.NewConfig().GetBech32ValidatorAddrPrefix())
+			cmd.Printf("Bech32 Con: %s\n", sdk.NewConfig().GetBech32ConsensusAddrPrefix())
 			return nil
 		},
 	}

--- a/client/keys/add.go
+++ b/client/keys/add.go
@@ -87,7 +87,7 @@ Example:
 	f.Bool(flagNoBackup, false, "Don't print out seed phrase (if others are watching the terminal)")
 	f.Bool(flags.FlagDryRun, false, "Perform action, but don't add key to local keystore")
 	f.String(flagHDPath, "", "Manual HD Path derivation (overrides BIP44 config)")
-	f.Uint32(flagCoinType, sdk.GetConfig().GetCoinType(), "coin type number for HD derivation")
+	f.Uint32(flagCoinType, sdk.NewConfig().GetCoinType(), "coin type number for HD derivation")
 	f.Uint32(flagAccount, 0, "Account number for HD derivation (less than equal 2147483647)")
 	f.Uint32(flagIndex, 0, "Address index number for HD derivation (less than equal 2147483647)")
 	f.String(flags.FlagKeyType, string(hd.Secp256k1Type), "Key signing algorithm to generate keys for")
@@ -266,7 +266,7 @@ func runAddCmd(ctx client.Context, cmd *cobra.Command, args []string, inBuf *buf
 
 	// If we're using ledger, only thing we need is the path and the bech32 prefix.
 	if useLedger {
-		bech32PrefixAccAddr := sdk.GetConfig().GetBech32AccountAddrPrefix()
+		bech32PrefixAccAddr := sdk.NewConfig().GetBech32AccountAddrPrefix()
 		k, err := kb.SaveLedgerKey(name, hd.Secp256k1, bech32PrefixAccAddr, coinType, account, index)
 		if err != nil {
 			return err

--- a/client/keys/add_ledger_test.go
+++ b/client/keys/add_ledger_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func Test_runAddCmdLedgerWithCustomCoinType(t *testing.T) {
-	config := sdk.GetConfig()
+	config := sdk.NewConfig()
 
 	bech32PrefixAccAddr := "terra"
 	bech32PrefixAccPub := "terrapub"

--- a/client/keys/add_test.go
+++ b/client/keys/add_test.go
@@ -219,7 +219,7 @@ func Test_runAddCmdDryRun(t *testing.T) {
 				WithKeyring(kb)
 			ctx := context.WithValue(context.Background(), client.ClientContextKey, &clientCtx)
 
-			path := sdk.GetConfig().GetFullBIP44Path()
+			path := sdk.NewConfig().GetFullBIP44Path()
 			_, err = kb.NewAccount("subkey", testdata.TestMnemonic, "", path, hd.Secp256k1)
 			require.NoError(t, err)
 

--- a/client/keys/delete_test.go
+++ b/client/keys/delete_test.go
@@ -33,7 +33,7 @@ func Test_runDeleteCmd(t *testing.T) {
 	fakeKeyName1 := "runDeleteCmd_Key1"
 	fakeKeyName2 := "runDeleteCmd_Key2"
 
-	path := sdk.GetConfig().GetFullBIP44Path()
+	path := sdk.NewConfig().GetFullBIP44Path()
 	cdc := moduletestutil.MakeTestEncodingConfig().Codec
 
 	cmd.SetArgs([]string{"blah", fmt.Sprintf("--%s=%s", flags.FlagKeyringDir, kbHome)})

--- a/client/keys/export_test.go
+++ b/client/keys/export_test.go
@@ -90,7 +90,7 @@ func Test_runExportCmd(t *testing.T) {
 			require.NoError(t, err)
 			t.Cleanup(cleanupKeys(t, kb, "keyname1"))
 
-			path := sdk.GetConfig().GetFullBIP44Path()
+			path := sdk.NewConfig().GetFullBIP44Path()
 			_, err = kb.NewAccount("keyname1", testdata.TestMnemonic, "", path, hd.Secp256k1)
 			require.NoError(t, err)
 

--- a/client/keys/list_test.go
+++ b/client/keys/list_test.go
@@ -44,7 +44,7 @@ func Test_runListCmd(t *testing.T) {
 	clientCtx := client.Context{}.WithKeyring(kb)
 	ctx := context.WithValue(context.Background(), client.ClientContextKey, &clientCtx)
 
-	path := "" // sdk.GetConfig().GetFullBIP44Path()
+	path := "" // sdk.NewConfig().GetFullBIP44Path()
 	_, err = kb.NewAccount("something", testdata.TestMnemonic, "", path, hd.Secp256k1)
 	assert.NilError(t, err)
 

--- a/client/keys/rename_test.go
+++ b/client/keys/rename_test.go
@@ -30,7 +30,7 @@ func Test_runRenameCmd(t *testing.T) {
 	fakeKeyName1 := "runRenameCmd_Key1"
 	fakeKeyName2 := "runRenameCmd_Key2"
 
-	path := sdk.GetConfig().GetFullBIP44Path()
+	path := sdk.NewConfig().GetFullBIP44Path()
 
 	cdc := moduletestutil.MakeTestEncodingConfig().Codec
 	kb, err := keyring.New(sdk.KeyringServiceName(), keyring.BackendTest, kbHome, mockIn, cdc)

--- a/client/keys/show.go
+++ b/client/keys/show.go
@@ -163,7 +163,7 @@ func runShowCmd(cmd *cobra.Command, args []string) (err error) {
 			return err
 		}
 
-		return ledger.ShowAddress(*ledgerItem.Path, pk, sdk.GetConfig().GetBech32AccountAddrPrefix())
+		return ledger.ShowAddress(*ledgerItem.Path, pk, sdk.NewConfig().GetBech32AccountAddrPrefix())
 	}
 
 	return nil

--- a/crypto/ledger/ledger_mock.go
+++ b/crypto/ledger/ledger_mock.go
@@ -42,7 +42,7 @@ func (mock LedgerSECP256K1Mock) GetPublicKeySECP256K1(derivationPath []uint32) (
 		return nil, errors.New("invalid derivation path")
 	}
 
-	if derivationPath[1] != sdk.GetConfig().GetCoinType() {
+	if derivationPath[1] != sdk.NewConfig().GetCoinType() {
 		return nil, errors.New("invalid derivation path")
 	}
 

--- a/crypto/ledger/ledger_test.go
+++ b/crypto/ledger/ledger_test.go
@@ -102,7 +102,7 @@ func TestPublicKeySafe(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, priv)
-	require.Nil(t, ShowAddress(path, priv.PubKey(), sdk.GetConfig().GetBech32AccountAddrPrefix()))
+	require.Nil(t, ShowAddress(path, priv.PubKey(), sdk.NewConfig().GetBech32AccountAddrPrefix()))
 	checkDefaultPubKey(t, priv)
 
 	addr2 := sdk.AccAddress(priv.PubKey().Address()).String()

--- a/server/grpc/server.go
+++ b/server/grpc/server.go
@@ -56,7 +56,7 @@ func NewGRPCServer(clientCtx client.Context, app types.Application, cfg config.G
 			return modes
 		}(),
 		ChainID:           clientCtx.ChainID,
-		SdkConfig:         sdk.GetConfig(),
+		SdkConfig:         sdk.NewConfig(),
 		InterfaceRegistry: clientCtx.InterfaceRegistry,
 	})
 	if err != nil {

--- a/simapp/app.go
+++ b/simapp/app.go
@@ -198,10 +198,10 @@ func NewSimApp(
 		ProtoFiles: proto.HybridResolver,
 		SigningOptions: signing.Options{
 			AddressCodec: address.Bech32Codec{
-				Bech32Prefix: sdk.GetConfig().GetBech32AccountAddrPrefix(),
+				Bech32Prefix: sdk.NewConfig().GetBech32AccountAddrPrefix(),
 			},
 			ValidatorAddressCodec: address.Bech32Codec{
-				Bech32Prefix: sdk.GetConfig().GetBech32ValidatorAddrPrefix(),
+				Bech32Prefix: sdk.NewConfig().GetBech32ValidatorAddrPrefix(),
 			},
 		},
 	})
@@ -674,9 +674,9 @@ func (app *SimApp) AutoCliOpts() autocli.AppOptions {
 	return autocli.AppOptions{
 		Modules:               modules,
 		ModuleOptions:         runtimeservices.ExtractAutoCLIOptions(app.ModuleManager.Modules),
-		AddressCodec:          authcodec.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix()),
-		ValidatorAddressCodec: authcodec.NewBech32Codec(sdk.GetConfig().GetBech32ValidatorAddrPrefix()),
-		ConsensusAddressCodec: authcodec.NewBech32Codec(sdk.GetConfig().GetBech32ConsensusAddrPrefix()),
+		AddressCodec:          authcodec.NewBech32Codec(sdk.NewConfig().GetBech32AccountAddrPrefix()),
+		ValidatorAddressCodec: authcodec.NewBech32Codec(sdk.NewConfig().GetBech32ValidatorAddrPrefix()),
+		ConsensusAddressCodec: authcodec.NewBech32Codec(sdk.NewConfig().GetBech32ConsensusAddrPrefix()),
 	}
 }
 

--- a/simapp/simd/cmd/commands.go
+++ b/simapp/simd/cmd/commands.go
@@ -104,7 +104,7 @@ func initRootCmd(
 	txConfig client.TxConfig,
 	basicManager module.BasicManager,
 ) {
-	cfg := sdk.GetConfig()
+	cfg := sdk.NewConfig()
 	cfg.Seal()
 
 	rootCmd.AddCommand(

--- a/testutil/key.go
+++ b/testutil/key.go
@@ -14,7 +14,7 @@ func GenerateCoinKey(algo keyring.SignatureAlgo, cdc codec.Codec) (sdk.AccAddres
 	info, secret, err := keyring.NewInMemory(cdc).NewMnemonic(
 		"name",
 		keyring.English,
-		sdk.GetConfig().GetFullBIP44Path(),
+		sdk.NewConfig().GetFullBIP44Path(),
 		keyring.DefaultBIP39Passphrase,
 		algo,
 	)
@@ -63,9 +63,9 @@ func GenerateSaveCoinKey(
 	// generate or recover a new account
 	if mnemonic != "" {
 		secret = mnemonic
-		record, err = keybase.NewAccount(keyName, mnemonic, keyring.DefaultBIP39Passphrase, sdk.GetConfig().GetFullBIP44Path(), algo)
+		record, err = keybase.NewAccount(keyName, mnemonic, keyring.DefaultBIP39Passphrase, sdk.NewConfig().GetFullBIP44Path(), algo)
 	} else {
-		record, secret, err = keybase.NewMnemonic(keyName, keyring.English, sdk.GetConfig().GetFullBIP44Path(), keyring.DefaultBIP39Passphrase, algo)
+		record, secret, err = keybase.NewMnemonic(keyName, keyring.English, sdk.NewConfig().GetFullBIP44Path(), keyring.DefaultBIP39Passphrase, algo)
 	}
 	if err != nil {
 		return sdk.AccAddress{}, "", err

--- a/testutil/key_test.go
+++ b/testutil/key_test.go
@@ -18,7 +18,7 @@ func TestGenerateCoinKey(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test creation
-	k, err := keyring.NewInMemory(cdc).NewAccount("xxx", mnemonic, "", hd.NewFundraiserParams(0, types.GetConfig().GetCoinType(), 0).String(), hd.Secp256k1)
+	k, err := keyring.NewInMemory(cdc).NewAccount("xxx", mnemonic, "", hd.NewFundraiserParams(0, types.NewConfig().GetCoinType(), 0).String(), hd.Secp256k1)
 	require.NoError(t, err)
 	addr1, err := k.GetAddress()
 	require.NoError(t, err)
@@ -43,7 +43,7 @@ func TestGenerateSaveCoinKey(t *testing.T) {
 	require.Equal(t, addr, addr1)
 
 	// Test in-memory recovery
-	k, err = keyring.NewInMemory(encCfg.Codec).NewAccount("xxx", mnemonic, "", hd.NewFundraiserParams(0, types.GetConfig().GetCoinType(), 0).String(), hd.Secp256k1)
+	k, err = keyring.NewInMemory(encCfg.Codec).NewAccount("xxx", mnemonic, "", hd.NewFundraiserParams(0, types.NewConfig().GetCoinType(), 0).String(), hd.Secp256k1)
 	require.NoError(t, err)
 	addr1, err = k.GetAddress()
 	require.NoError(t, err)

--- a/types/address.go
+++ b/types/address.go
@@ -160,11 +160,11 @@ func AccAddressFromHexUnsafe(address string) (addr AccAddress, err error) {
 
 // VerifyAddressFormat verifies that the provided bytes form a valid address
 // according to the default address rules or a custom address verifier set by
-// GetConfig().SetAddressVerifier().
+// NewConfig().SetAddressVerifier().
 // TODO make an issue to get rid of global Config
 // ref: https://github.com/cosmos/cosmos-sdk/issues/9690
 func VerifyAddressFormat(bz []byte) error {
-	verifier := GetConfig().GetAddressVerifier()
+	verifier := NewConfig().GetAddressVerifier()
 	if verifier != nil {
 		return verifier(bz)
 	}
@@ -196,7 +196,7 @@ func AccAddressFromBech32(address string) (addr AccAddress, err error) {
 		return AccAddress{}, errors.New("empty address string is not allowed")
 	}
 
-	bech32PrefixAccAddr := GetConfig().GetBech32AccountAddrPrefix()
+	bech32PrefixAccAddr := NewConfig().GetBech32AccountAddrPrefix()
 
 	bz, err := GetFromBech32(address, bech32PrefixAccAddr)
 	if err != nil {
@@ -312,7 +312,7 @@ func (aa AccAddress) String() string {
 			return addr.(string)
 		}
 	}
-	return cacheBech32Addr(GetConfig().GetBech32AccountAddrPrefix(), aa, accAddrCache, key)
+	return cacheBech32Addr(NewConfig().GetBech32AccountAddrPrefix(), aa, accAddrCache, key)
 }
 
 // Format implements the fmt.Formatter interface.
@@ -348,7 +348,7 @@ func ValAddressFromBech32(address string) (addr ValAddress, err error) {
 		return ValAddress{}, errors.New("empty address string is not allowed")
 	}
 
-	bech32PrefixValAddr := GetConfig().GetBech32ValidatorAddrPrefix()
+	bech32PrefixValAddr := NewConfig().GetBech32ValidatorAddrPrefix()
 
 	bz, err := GetFromBech32(address, bech32PrefixValAddr)
 	if err != nil {
@@ -466,7 +466,7 @@ func (va ValAddress) String() string {
 			return addr.(string)
 		}
 	}
-	return cacheBech32Addr(GetConfig().GetBech32ValidatorAddrPrefix(), va, valAddrCache, key)
+	return cacheBech32Addr(NewConfig().GetBech32ValidatorAddrPrefix(), va, valAddrCache, key)
 }
 
 // Format implements the fmt.Formatter interface.
@@ -503,7 +503,7 @@ func ConsAddressFromBech32(address string) (addr ConsAddress, err error) {
 		return ConsAddress{}, errors.New("empty address string is not allowed")
 	}
 
-	bech32PrefixConsAddr := GetConfig().GetBech32ConsensusAddrPrefix()
+	bech32PrefixConsAddr := NewConfig().GetBech32ConsensusAddrPrefix()
 
 	bz, err := GetFromBech32(address, bech32PrefixConsAddr)
 	if err != nil {
@@ -626,7 +626,7 @@ func (ca ConsAddress) String() string {
 			return addr.(string)
 		}
 	}
-	return cacheBech32Addr(GetConfig().GetBech32ConsensusAddrPrefix(), ca, consAddrCache, key)
+	return cacheBech32Addr(NewConfig().GetBech32ConsensusAddrPrefix(), ca, consAddrCache, key)
 }
 
 // Bech32ifyAddressBytes returns a bech32 representation of address bytes.

--- a/types/address.go
+++ b/types/address.go
@@ -27,7 +27,7 @@ const (
 	// You can use the specific values for your project.
 	// Add the follow lines to the `main()` of your server.
 	//
-	//	config := sdk.GetConfig()
+	//	config := sdk.NewConfig()
 	//	config.SetBech32PrefixForAccount(yourBech32PrefixAccAddr, yourBech32PrefixAccPub)
 	//	config.SetBech32PrefixForValidator(yourBech32PrefixValAddr, yourBech32PrefixValPub)
 	//	config.SetBech32PrefixForConsensusNode(yourBech32PrefixConsAddr, yourBech32PrefixConsPub)

--- a/types/address_test.go
+++ b/types/address_test.go
@@ -137,7 +137,7 @@ func (s *addressTestSuite) TestAddrCache() {
 
 	// Set SDK bech32 prefixes to 'osmo'
 	prefix := "osmo"
-	conf := types.GetConfig()
+	conf := types.NewConfig()
 	conf.SetBech32PrefixForAccount(prefix, prefix+"pub")
 	conf.SetBech32PrefixForValidator(prefix+"valoper", prefix+"valoperpub")
 	conf.SetBech32PrefixForConsensusNode(prefix+"valcons", prefix+"valconspub")
@@ -174,7 +174,7 @@ func (s *addressTestSuite) TestAddrCacheDisabled() {
 
 	// Set SDK bech32 prefixes to 'osmo'
 	prefix := "osmo"
-	conf := types.GetConfig()
+	conf := types.NewConfig()
 	conf.SetBech32PrefixForAccount(prefix, prefix+"pub")
 	conf.SetBech32PrefixForValidator(prefix+"valoper", prefix+"valoperpub")
 	conf.SetBech32PrefixForConsensusNode(prefix+"valcons", prefix+"valconspub")
@@ -298,7 +298,7 @@ func (s *addressTestSuite) TestConfiguredPrefix() {
 			prefix := RandString(length)
 
 			// Assuming that GetConfig is not sealed.
-			config := types.GetConfig()
+			config := types.NewConfig()
 			config.SetBech32PrefixForAccount(
 				prefix+types.PrefixAccount,
 				prefix+types.PrefixPublic)
@@ -410,7 +410,7 @@ func (s *addressTestSuite) TestCustomAddressVerifier() {
 	s.Require().Nil(err)
 
 	// Set a custom address verifier only accepts 20 byte addresses
-	types.GetConfig().SetAddressVerifier(func(bz []byte) error {
+	types.NewConfig().SetAddressVerifier(func(bz []byte) error {
 		n := len(bz)
 		if n == 20 {
 			return nil
@@ -429,7 +429,7 @@ func (s *addressTestSuite) TestCustomAddressVerifier() {
 	s.Require().NotNil(err)
 
 	// Reinitialize the global config to default address verifier (nil)
-	types.GetConfig().SetAddressVerifier(nil)
+	types.NewConfig().SetAddressVerifier(nil)
 }
 
 func (s *addressTestSuite) TestBech32ifyAddressBytes() {

--- a/types/bech32/legacybech32/pk.go
+++ b/types/bech32/legacybech32/pk.go
@@ -41,7 +41,7 @@ func MustMarshalPubKey(pkt Bech32PubKeyType, pubkey cryptotypes.PubKey) string {
 }
 
 func getPrefix(pkt Bech32PubKeyType) string {
-	cfg := sdk.GetConfig()
+	cfg := sdk.NewConfig()
 	switch pkt {
 	case AccPK:
 		return cfg.GetBech32AccountPubPrefix()

--- a/types/config.go
+++ b/types/config.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -30,8 +31,7 @@ type Config struct {
 
 // cosmos-sdk wide global singleton
 var (
-	sdkConfig  *Config
-	initConfig sync.Once
+	sdkConfig *Config
 )
 
 // New returns a new Config with default values.
@@ -56,15 +56,17 @@ func NewConfig() *Config {
 
 // GetConfig returns the config instance for the SDK.
 func GetConfig() *Config {
-	initConfig.Do(func() {
-		sdkConfig = NewConfig()
-	})
-	return sdkConfig
+	panic(errors.New("deprecated: global config is deprecated. Please migrate to version XXX"))
 }
 
 // GetSealedConfig returns the config instance for the SDK if/once it is sealed.
 func GetSealedConfig(ctx context.Context) (*Config, error) {
-	config := GetConfig()
+	// probably still should be in sync.Once block but this is fine for testing
+	config := sdkConfig
+	if sdkConfig == nil {
+		sdkConfig = NewConfig()
+		config = sdkConfig
+	}
 	select {
 	case <-config.sealedch:
 		return config, nil

--- a/x/auth/tx/config.go
+++ b/x/auth/tx/config.go
@@ -89,7 +89,7 @@ func NewTxConfig(protoCodec codec.Codec, enabledSignModes []signingtypes.SignMod
 // NewDefaultSigningOptions returns the sdk default signing options used by x/tx.  This includes account and
 // validator address prefix enabled codecs.
 func NewDefaultSigningOptions() (*txsigning.Options, error) {
-	sdkConfig := sdk.GetConfig()
+	sdkConfig := sdk.NewConfig()
 	return &txsigning.Options{
 		AddressCodec:          authcodec.NewBech32Codec(sdkConfig.GetBech32AccountAddrPrefix()),
 		ValidatorAddressCodec: authcodec.NewBech32Codec(sdkConfig.GetBech32ValidatorAddrPrefix()),

--- a/x/distribution/client/cli/tx.go
+++ b/x/distribution/client/cli/tx.go
@@ -78,7 +78,7 @@ func newSplitAndApply(
 
 // NewWithdrawRewardsCmd returns a CLI command handler for creating a MsgWithdrawDelegatorReward transaction.
 func NewWithdrawRewardsCmd(valCodec, ac address.Codec) *cobra.Command {
-	bech32PrefixValAddr := sdk.GetConfig().GetBech32ValidatorAddrPrefix()
+	bech32PrefixValAddr := sdk.NewConfig().GetBech32ValidatorAddrPrefix()
 
 	cmd := &cobra.Command{
 		Use:   "withdraw-rewards [validator-addr]",
@@ -191,7 +191,7 @@ $ %[1]s tx distribution withdraw-all-rewards --from mykey
 
 // NewSetWithdrawAddrCmd returns a CLI command handler for creating a MsgSetWithdrawAddress transaction.
 func NewSetWithdrawAddrCmd(ac address.Codec) *cobra.Command {
-	bech32PrefixAccAddr := sdk.GetConfig().GetBech32AccountAddrPrefix()
+	bech32PrefixAccAddr := sdk.NewConfig().GetBech32AccountAddrPrefix()
 
 	cmd := &cobra.Command{
 		Use:   "set-withdraw-addr [withdraw-addr]",

--- a/x/evidence/types/evidence_test.go
+++ b/x/evidence/types/evidence_test.go
@@ -73,7 +73,7 @@ func TestEquivocationValidateBasic(t *testing.T) {
 }
 
 func TestEvidenceAddressConversion(t *testing.T) {
-	sdk.GetConfig().SetBech32PrefixForConsensusNode("testcnclcons", "testcnclconspub")
+	sdk.NewConfig().SetBech32PrefixForConsensusNode("testcnclcons", "testcnclconspub")
 	tmEvidence := NewCometMisbehavior(1, 100, time.Now(), comet.DuplicateVote,
 		validator{address: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, power: 100})
 
@@ -81,7 +81,7 @@ func TestEvidenceAddressConversion(t *testing.T) {
 	consAddr := evidence.GetConsensusAddress(address.NewBech32Codec("testcnclcons"))
 	// Check the address is the same after conversion
 	require.Equal(t, tmEvidence.Validator().Address(), consAddr.Bytes())
-	sdk.GetConfig().SetBech32PrefixForConsensusNode(sdk.Bech32PrefixConsAddr, sdk.Bech32PrefixConsPub)
+	sdk.NewConfig().SetBech32PrefixForConsensusNode(sdk.Bech32PrefixConsAddr, sdk.Bech32PrefixConsPub)
 }
 
 type Misbehavior struct {

--- a/x/staking/client/cli/tx.go
+++ b/x/staking/client/cli/tx.go
@@ -278,7 +278,7 @@ $ %s tx staking redelegate cosmosvalopers1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj
 
 // NewUnbondCmd returns a CLI command handler for creating a MsgUndelegate transaction.
 func NewUnbondCmd(valAddrCodec, ac address.Codec) *cobra.Command {
-	bech32PrefixValAddr := sdk.GetConfig().GetBech32ValidatorAddrPrefix()
+	bech32PrefixValAddr := sdk.NewConfig().GetBech32ValidatorAddrPrefix()
 
 	cmd := &cobra.Command{
 		Use:   "unbond [validator-addr] [amount]",
@@ -326,7 +326,7 @@ $ %s tx staking unbond %s1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj 100stake --from
 
 // NewCancelUnbondingDelegation returns a CLI command handler for creating a MsgCancelUnbondingDelegation transaction.
 func NewCancelUnbondingDelegation(valAddrCodec, ac address.Codec) *cobra.Command {
-	bech32PrefixValAddr := sdk.GetConfig().GetBech32ValidatorAddrPrefix()
+	bech32PrefixValAddr := sdk.NewConfig().GetBech32ValidatorAddrPrefix()
 
 	cmd := &cobra.Command{
 		Use:   "cancel-unbond [validator-addr] [amount] [creation-height]",


### PR DESCRIPTION
## Description

This is definitely a breaking change, making draft

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] added `!` to the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] run `make lint` and `make test`
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
