### PR TITLE
chore: add span attribute for full grpc request

### DIFF
--- a/baseapp/grpcserver.go
+++ b/baseapp/grpcserver.go
@@ -2,6 +2,7 @@ package baseapp
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 
 	gogogrpc "github.com/cosmos/gogoproto/grpc"
@@ -81,6 +82,7 @@ func (app *BaseApp) RegisterGRPCServer(server gogogrpc.Server) {
 		defer span.End()
 
 		span.SetAttributes(attribute.String("http.method", grpcInfo.FullMethod))
+		span.SetAttributes(attribute.String("http.request", fmt.Sprintf("%+v", req)))
 
 		resp, err = handler(grpcCtx, req)
 


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description
Adds a span to the GRPC server which includes the request body to improve traceability of incoming requests